### PR TITLE
 feat(kube-stack): add top-level resourceAttributes

### DIFF
--- a/charts/opentelemetry-kube-stack/Chart.yaml
+++ b/charts/opentelemetry-kube-stack/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 name: opentelemetry-kube-stack
-version: 0.20.6
+version: 0.20.7
 description: |
   OpenTelemetry Quickstart chart for Kubernetes.
   Installs an operator and collector for an easy way to get started with Kubernetes observability.

--- a/charts/opentelemetry-kube-stack/examples/cloud-demo/rendered/bridge.yaml
+++ b/charts/opentelemetry-kube-stack/examples/cloud-demo/rendered/bridge.yaml
@@ -5,7 +5,7 @@ kind: OpAMPBridge
 metadata:
   name: example
   labels:
-    helm.sh/chart: opentelemetry-kube-stack-0.20.6
+    helm.sh/chart: opentelemetry-kube-stack-0.20.7
     app.kubernetes.io/version: "0.154.0"
     app.kubernetes.io/managed-by: Helm
     release: "example"    

--- a/charts/opentelemetry-kube-stack/examples/cloud-demo/rendered/collector.yaml
+++ b/charts/opentelemetry-kube-stack/examples/cloud-demo/rendered/collector.yaml
@@ -6,7 +6,7 @@ metadata:
   name: example-daemon
   namespace: default
   labels:
-    helm.sh/chart: opentelemetry-kube-stack-0.20.6
+    helm.sh/chart: opentelemetry-kube-stack-0.20.7
     app.kubernetes.io/version: "0.154.0"
     app.kubernetes.io/managed-by: Helm
     release: "example"        

--- a/charts/opentelemetry-kube-stack/examples/cloud-demo/rendered/hooks.yaml
+++ b/charts/opentelemetry-kube-stack/examples/cloud-demo/rendered/hooks.yaml
@@ -61,4 +61,4 @@ spec:
           - "delete"
           - "instrumentations,opampbridges,opentelemetrycollectors"
           - "-l"
-          - "helm.sh/chart=opentelemetry-kube-stack-0.20.6"
+          - "helm.sh/chart=opentelemetry-kube-stack-0.20.7"

--- a/charts/opentelemetry-kube-stack/examples/cloud-demo/rendered/instrumentation.yaml
+++ b/charts/opentelemetry-kube-stack/examples/cloud-demo/rendered/instrumentation.yaml
@@ -5,7 +5,7 @@ kind: Instrumentation
 metadata:
   name: example
   labels:
-    helm.sh/chart: opentelemetry-kube-stack-0.20.6
+    helm.sh/chart: opentelemetry-kube-stack-0.20.7
     app.kubernetes.io/version: "0.154.0"
     app.kubernetes.io/managed-by: Helm
     release: "example"    

--- a/charts/opentelemetry-kube-stack/examples/daemonset-annotation-discovery-logs/rendered/collector.yaml
+++ b/charts/opentelemetry-kube-stack/examples/daemonset-annotation-discovery-logs/rendered/collector.yaml
@@ -6,7 +6,7 @@ metadata:
   name: example-daemon
   namespace: default
   labels:
-    helm.sh/chart: opentelemetry-kube-stack-0.20.6
+    helm.sh/chart: opentelemetry-kube-stack-0.20.7
     app.kubernetes.io/version: "0.154.0"
     app.kubernetes.io/managed-by: Helm
     release: "example"        

--- a/charts/opentelemetry-kube-stack/examples/daemonset-annotation-discovery-logs/rendered/hooks.yaml
+++ b/charts/opentelemetry-kube-stack/examples/daemonset-annotation-discovery-logs/rendered/hooks.yaml
@@ -61,4 +61,4 @@ spec:
           - "delete"
           - "instrumentations,opampbridges,opentelemetrycollectors"
           - "-l"
-          - "helm.sh/chart=opentelemetry-kube-stack-0.20.6"
+          - "helm.sh/chart=opentelemetry-kube-stack-0.20.7"

--- a/charts/opentelemetry-kube-stack/examples/daemonset-annotation-discovery-metrics/rendered/collector.yaml
+++ b/charts/opentelemetry-kube-stack/examples/daemonset-annotation-discovery-metrics/rendered/collector.yaml
@@ -6,7 +6,7 @@ metadata:
   name: example-daemon
   namespace: default
   labels:
-    helm.sh/chart: opentelemetry-kube-stack-0.20.6
+    helm.sh/chart: opentelemetry-kube-stack-0.20.7
     app.kubernetes.io/version: "0.154.0"
     app.kubernetes.io/managed-by: Helm
     release: "example"        

--- a/charts/opentelemetry-kube-stack/examples/daemonset-annotation-discovery-metrics/rendered/hooks.yaml
+++ b/charts/opentelemetry-kube-stack/examples/daemonset-annotation-discovery-metrics/rendered/hooks.yaml
@@ -61,4 +61,4 @@ spec:
           - "delete"
           - "instrumentations,opampbridges,opentelemetrycollectors"
           - "-l"
-          - "helm.sh/chart=opentelemetry-kube-stack-0.20.6"
+          - "helm.sh/chart=opentelemetry-kube-stack-0.20.7"

--- a/charts/opentelemetry-kube-stack/examples/daemonset-annotation-discovery/rendered/collector.yaml
+++ b/charts/opentelemetry-kube-stack/examples/daemonset-annotation-discovery/rendered/collector.yaml
@@ -6,7 +6,7 @@ metadata:
   name: example-daemon
   namespace: default
   labels:
-    helm.sh/chart: opentelemetry-kube-stack-0.20.6
+    helm.sh/chart: opentelemetry-kube-stack-0.20.7
     app.kubernetes.io/version: "0.154.0"
     app.kubernetes.io/managed-by: Helm
     release: "example"        

--- a/charts/opentelemetry-kube-stack/examples/daemonset-annotation-discovery/rendered/hooks.yaml
+++ b/charts/opentelemetry-kube-stack/examples/daemonset-annotation-discovery/rendered/hooks.yaml
@@ -61,4 +61,4 @@ spec:
           - "delete"
           - "instrumentations,opampbridges,opentelemetrycollectors"
           - "-l"
-          - "helm.sh/chart=opentelemetry-kube-stack-0.20.6"
+          - "helm.sh/chart=opentelemetry-kube-stack-0.20.7"

--- a/charts/opentelemetry-kube-stack/examples/daemonset-kubernetes-objects/rendered/collector.yaml
+++ b/charts/opentelemetry-kube-stack/examples/daemonset-kubernetes-objects/rendered/collector.yaml
@@ -6,7 +6,7 @@ metadata:
   name: example-daemon
   namespace: default
   labels:
-    helm.sh/chart: opentelemetry-kube-stack-0.20.6
+    helm.sh/chart: opentelemetry-kube-stack-0.20.7
     app.kubernetes.io/version: "0.154.0"
     app.kubernetes.io/managed-by: Helm
     release: "example"        

--- a/charts/opentelemetry-kube-stack/examples/daemonset-kubernetes-objects/rendered/hooks.yaml
+++ b/charts/opentelemetry-kube-stack/examples/daemonset-kubernetes-objects/rendered/hooks.yaml
@@ -61,4 +61,4 @@ spec:
           - "delete"
           - "instrumentations,opampbridges,opentelemetrycollectors"
           - "-l"
-          - "helm.sh/chart=opentelemetry-kube-stack-0.20.6"
+          - "helm.sh/chart=opentelemetry-kube-stack-0.20.7"

--- a/charts/opentelemetry-kube-stack/examples/daemonset-prometheus-presets/rendered/collector.yaml
+++ b/charts/opentelemetry-kube-stack/examples/daemonset-prometheus-presets/rendered/collector.yaml
@@ -6,7 +6,7 @@ metadata:
   name: example-daemon
   namespace: default
   labels:
-    helm.sh/chart: opentelemetry-kube-stack-0.20.6
+    helm.sh/chart: opentelemetry-kube-stack-0.20.7
     app.kubernetes.io/version: "0.154.0"
     app.kubernetes.io/managed-by: Helm
     release: "example"        

--- a/charts/opentelemetry-kube-stack/examples/daemonset-prometheus-presets/rendered/hooks.yaml
+++ b/charts/opentelemetry-kube-stack/examples/daemonset-prometheus-presets/rendered/hooks.yaml
@@ -61,4 +61,4 @@ spec:
           - "delete"
           - "instrumentations,opampbridges,opentelemetrycollectors"
           - "-l"
-          - "helm.sh/chart=opentelemetry-kube-stack-0.20.6"
+          - "helm.sh/chart=opentelemetry-kube-stack-0.20.7"

--- a/charts/opentelemetry-kube-stack/examples/default/rendered/collector.yaml
+++ b/charts/opentelemetry-kube-stack/examples/default/rendered/collector.yaml
@@ -6,7 +6,7 @@ metadata:
   name: example-daemon
   namespace: default
   labels:
-    helm.sh/chart: opentelemetry-kube-stack-0.20.6
+    helm.sh/chart: opentelemetry-kube-stack-0.20.7
     app.kubernetes.io/version: "0.154.0"
     app.kubernetes.io/managed-by: Helm
     release: "example"        

--- a/charts/opentelemetry-kube-stack/examples/default/rendered/hooks.yaml
+++ b/charts/opentelemetry-kube-stack/examples/default/rendered/hooks.yaml
@@ -61,4 +61,4 @@ spec:
           - "delete"
           - "instrumentations,opampbridges,opentelemetrycollectors"
           - "-l"
-          - "helm.sh/chart=opentelemetry-kube-stack-0.20.6"
+          - "helm.sh/chart=opentelemetry-kube-stack-0.20.7"

--- a/charts/opentelemetry-kube-stack/examples/global-resource-attributes/rendered/clusterrole.yaml
+++ b/charts/opentelemetry-kube-stack/examples/global-resource-attributes/rendered/clusterrole.yaml
@@ -1,0 +1,162 @@
+---
+# Source: opentelemetry-kube-stack/templates/clusterrole.yaml
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: example-collector
+rules:
+- apiGroups: [""]
+  resources:
+  - namespaces
+  - nodes
+  - nodes/proxy
+  - nodes/metrics
+  - nodes/stats
+  - services
+  - endpoints
+  - pods
+  - events
+  - secrets
+  - persistentvolumeclaims
+  - persistentvolumes
+  verbs: ["get", "list", "watch"]
+- apiGroups: ["monitoring.coreos.com"]
+  resources:
+  - servicemonitors
+  - podmonitors
+  - scrapeconfigs
+  - probes
+  verbs: ["get", "list", "watch"]
+- apiGroups:
+  - extensions
+  resources:
+  - ingresses
+  verbs: ["get", "list", "watch"]
+- apiGroups:
+  - apps
+  resources:
+  - daemonsets
+  - deployments
+  - replicasets
+  - statefulsets
+  verbs: ["get", "list", "watch"]
+- apiGroups:
+  - networking.k8s.io
+  resources:
+  - ingresses
+  verbs: ["get", "list", "watch"]
+- apiGroups: ["discovery.k8s.io"]
+  resources:
+  - endpointslices
+  verbs: ["get", "list", "watch"]
+- nonResourceURLs: ["/metrics", "/metrics/cadvisor"]
+  verbs: ["get"]
+
+- verbs:
+  - get
+  - list
+  - watch
+  - create
+  - update
+  - patch
+  - delete
+  apiGroups:
+  - coordination.k8s.io
+  resources:
+  - leases
+- apiGroups:
+  - ""
+  resources:
+  - events
+  - namespaces
+  - namespaces/status
+  - nodes
+  - nodes/spec
+  - pods
+  - pods/status
+  - replicationcontrollers
+  - replicationcontrollers/status
+  - resourcequotas
+  - services
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - apps
+  resources:
+  - daemonsets
+  - deployments
+  - replicasets
+  - statefulsets
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - extensions
+  resources:
+  - daemonsets
+  - deployments
+  - replicasets
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - batch
+  resources:
+  - jobs
+  - cronjobs
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+    - autoscaling
+  resources:
+    - horizontalpodautoscalers
+  verbs:
+    - get
+    - list
+    - watch
+- apiGroups: ["events.k8s.io"]
+  resources: ["events"]
+  verbs: ["watch", "list"]
+- apiGroups: [""]
+  resources: ["nodes"]
+  verbs: ["get", "list"]
+- apiGroups: [""]
+  resources: ["namespaces"]
+  resourceNames: ["kube-system"]
+  verbs: ["get"]
+---
+# Source: opentelemetry-kube-stack/templates/clusterrole.yaml
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: example-collector
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: example-collector
+subjects:
+- kind: ServiceAccount
+  # quirk of the Operator
+  name: "example-collector-collector"
+  namespace: default
+---
+# Source: opentelemetry-kube-stack/templates/clusterrole.yaml
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: example-daemon
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: example-collector
+subjects:
+- kind: ServiceAccount
+  # quirk of the Operator
+  name: "example-daemon-collector"
+  namespace: default

--- a/charts/opentelemetry-kube-stack/examples/global-resource-attributes/rendered/collector.yaml
+++ b/charts/opentelemetry-kube-stack/examples/global-resource-attributes/rendered/collector.yaml
@@ -1,0 +1,677 @@
+---
+# Source: opentelemetry-kube-stack/templates/collector.yaml
+apiVersion: opentelemetry.io/v1beta1
+kind: OpenTelemetryCollector
+metadata:
+  name: example-collector
+  namespace: default
+  labels:
+    helm.sh/chart: opentelemetry-kube-stack-0.20.7
+    app.kubernetes.io/version: "0.154.0"
+    app.kubernetes.io/managed-by: Helm
+    release: "example"        
+spec:
+  managementState: managed
+  mode: deployment
+  config:
+    exporters:
+      otlp_http:
+        endpoint: https://otlp.example.com:4318
+    extensions:
+      k8s_leader_elector/k8s_cluster:
+        auth_type: serviceAccount
+        lease_name: k8s.cluster.receiver.opentelemetry.io
+        lease_namespace: default
+      k8s_leader_elector/k8s_objects:
+        auth_type: serviceAccount
+        lease_name: k8s.objects.receiver.opentelemetry.io
+        lease_namespace: default
+    processors:
+      k8s_attributes:
+        extract:
+          labels:
+          - from: pod
+            key: app.kubernetes.io/instance
+            tag_name: k8s.app.instance
+          - from: pod
+            key: app.kubernetes.io/component
+            tag_name: k8s.app.component
+          metadata:
+          - k8s.namespace.name
+          - k8s.pod.name
+          - k8s.pod.uid
+          - k8s.node.name
+          - k8s.pod.start_time
+          - k8s.deployment.name
+          - k8s.replicaset.name
+          - k8s.replicaset.uid
+          - k8s.daemonset.name
+          - k8s.daemonset.uid
+          - k8s.job.name
+          - k8s.job.uid
+          - k8s.container.name
+          - k8s.cronjob.name
+          - k8s.statefulset.name
+          - k8s.statefulset.uid
+          - container.image.tag
+          - container.image.name
+          - k8s.cluster.uid
+          - service.namespace
+          - service.name
+          - service.version
+          - service.instance.id
+          otel_annotations: true
+        passthrough: false
+        pod_association:
+        - sources:
+          - from: resource_attribute
+            name: k8s.pod.uid
+        - sources:
+          - from: resource_attribute
+            name: k8s.pod.name
+          - from: resource_attribute
+            name: k8s.namespace.name
+          - from: resource_attribute
+            name: k8s.node.name
+        - sources:
+          - from: resource_attribute
+            name: k8s.pod.ip
+        - sources:
+          - from: resource_attribute
+            name: k8s.pod.name
+          - from: resource_attribute
+            name: k8s.namespace.name
+        - sources:
+          - from: connection
+      resource/global:
+        attributes:
+        - action: upsert
+          key: deployment.environment.name
+          value: production
+        - action: upsert
+          key: k8s.cluster.name
+          value: my_k8s_cluster
+    receivers:
+      k8s_cluster:
+        allocatable_types_to_report:
+        - cpu
+        - memory
+        - storage
+        auth_type: serviceAccount
+        collection_interval: 10s
+        k8s_leader_elector: k8s_leader_elector/k8s_cluster
+        node_conditions_to_report:
+        - Ready
+        - MemoryPressure
+        - DiskPressure
+        - NetworkUnavailable
+      k8s_objects:
+        k8s_leader_elector: k8s_leader_elector/k8s_objects
+        objects:
+        - exclude_watch_type:
+          - DELETED
+          group: events.k8s.io
+          mode: watch
+          name: events
+    service:
+      extensions:
+      - k8s_leader_elector/k8s_objects
+      - k8s_leader_elector/k8s_cluster
+      pipelines:
+        logs:
+          exporters:
+          - otlp_http
+          processors:
+          - k8s_attributes
+          - resource/global
+          receivers:
+          - k8s_objects
+        metrics:
+          exporters:
+          - otlp_http
+          processors:
+          - k8s_attributes
+          - resource/global
+          receivers:
+          - k8s_cluster
+        traces:
+          exporters:
+          - otlp_http
+          processors:
+          - k8s_attributes
+          - resource/global
+  replicas: 
+  imagePullPolicy: IfNotPresent
+  upgradeStrategy: automatic
+  terminationGracePeriodSeconds: 30
+  resources:
+    limits:
+      cpu: 250m
+      memory: 128Mi
+    requests:
+      cpu: 250m
+      memory: 64Mi
+  securityContext:
+    {}
+  env:
+  - name: K8S_NODE_NAME 
+    valueFrom:
+      fieldRef:
+        fieldPath: spec.nodeName
+  - name: OTEL_K8S_NODE_NAME
+    valueFrom:
+      fieldRef:
+        fieldPath: spec.nodeName
+  - name: OTEL_K8S_NODE_IP
+    valueFrom:
+      fieldRef:
+        fieldPath: status.hostIP
+  - name: OTEL_K8S_NAMESPACE
+    valueFrom:
+      fieldRef:
+        apiVersion: v1
+        fieldPath: metadata.namespace
+  - name: OTEL_K8S_POD_NAME
+    valueFrom:
+      fieldRef:
+        apiVersion: v1
+        fieldPath: metadata.name
+  - name: OTEL_K8S_POD_IP
+    valueFrom:
+      fieldRef:
+        apiVersion: v1
+        fieldPath: status.podIP
+  - name: OTEL_RESOURCE_ATTRIBUTES
+    value: "k8s.pod.name=$(OTEL_K8S_POD_NAME),k8s.namespace.name=$(OTEL_K8S_NAMESPACE),k8s.node.name=$(OTEL_K8S_NODE_NAME),host.name=$(OTEL_K8S_NODE_NAME),k8s.node.ip=$(OTEL_K8S_NODE_IP),k8s.pod.ip=$(OTEL_K8S_POD_IP),k8s.cluster.name=unknown_k8s_cluster"
+---
+# Source: opentelemetry-kube-stack/templates/collector.yaml
+apiVersion: opentelemetry.io/v1beta1
+kind: OpenTelemetryCollector
+metadata:
+  name: example-daemon
+  namespace: default
+  labels:
+    helm.sh/chart: opentelemetry-kube-stack-0.20.7
+    app.kubernetes.io/version: "0.154.0"
+    app.kubernetes.io/managed-by: Helm
+    release: "example"        
+spec:
+  managementState: managed
+  mode: daemonset
+  config:
+    exporters:
+      debug: {}
+      otlp_http:
+        endpoint: https://otlp.example.com:4318
+    processors:
+      batch:
+        send_batch_max_size: 1500
+        send_batch_size: 1000
+        timeout: 1s
+      k8s_attributes:
+        extract:
+          labels:
+          - from: pod
+            key: app.kubernetes.io/instance
+            tag_name: k8s.app.instance
+          - from: pod
+            key: app.kubernetes.io/component
+            tag_name: k8s.app.component
+          metadata:
+          - k8s.namespace.name
+          - k8s.pod.name
+          - k8s.pod.uid
+          - k8s.node.name
+          - k8s.pod.start_time
+          - k8s.deployment.name
+          - k8s.replicaset.name
+          - k8s.replicaset.uid
+          - k8s.daemonset.name
+          - k8s.daemonset.uid
+          - k8s.job.name
+          - k8s.job.uid
+          - k8s.container.name
+          - k8s.cronjob.name
+          - k8s.statefulset.name
+          - k8s.statefulset.uid
+          - container.image.tag
+          - container.image.name
+          - k8s.cluster.uid
+          - service.namespace
+          - service.name
+          - service.version
+          - service.instance.id
+          otel_annotations: true
+        filter:
+          node_from_env_var: OTEL_K8S_NODE_NAME
+        passthrough: false
+        pod_association:
+        - sources:
+          - from: resource_attribute
+            name: k8s.pod.uid
+        - sources:
+          - from: resource_attribute
+            name: k8s.pod.name
+          - from: resource_attribute
+            name: k8s.namespace.name
+          - from: resource_attribute
+            name: k8s.node.name
+        - sources:
+          - from: resource_attribute
+            name: k8s.pod.ip
+        - sources:
+          - from: resource_attribute
+            name: k8s.pod.name
+          - from: resource_attribute
+            name: k8s.namespace.name
+        - sources:
+          - from: connection
+      resource/global:
+        attributes:
+        - action: upsert
+          key: deployment.environment.name
+          value: production
+        - action: upsert
+          key: k8s.cluster.name
+          value: my_k8s_cluster
+      resource/hostname:
+        attributes:
+        - action: insert
+          from_attribute: k8s.node.name
+          key: host.name
+      resource_detection/env:
+        detectors:
+        - env
+        - k8s_api
+        override: false
+        timeout: 2s
+    receivers:
+      file_log:
+        exclude: []
+        include:
+        - /var/log/pods/*/*/*.log
+        include_file_name: false
+        include_file_path: true
+        operators:
+        - id: container-parser
+          max_log_size: 102400
+          type: container
+        retry_on_failure:
+          enabled: true
+        start_at: end
+      host_metrics:
+        collection_interval: 10s
+        root_path: /hostfs
+        scrapers:
+          cpu:
+            metrics:
+              system.cpu.logical.count:
+                enabled: true
+              system.cpu.utilization:
+                enabled: true
+          disk: {}
+          filesystem:
+            exclude_fs_types:
+              fs_types:
+              - autofs
+              - binfmt_misc
+              - bpf
+              - cgroup2
+              - configfs
+              - debugfs
+              - devpts
+              - devtmpfs
+              - fusectl
+              - hugetlbfs
+              - iso9660
+              - mqueue
+              - nsfs
+              - overlay
+              - proc
+              - procfs
+              - pstore
+              - rpc_pipefs
+              - securityfs
+              - selinuxfs
+              - squashfs
+              - sysfs
+              - tracefs
+              match_type: strict
+            exclude_mount_points:
+              match_type: regexp
+              mount_points:
+              - /dev/*
+              - /proc/*
+              - /sys/*
+              - /run/k3s/containerd/*
+              - /var/lib/docker/*
+              - /var/lib/kubelet/*
+              - /snap/*
+            metrics:
+              system.filesystem.utilization:
+                enabled: true
+          load: {}
+          memory:
+            metrics:
+              system.memory.limit:
+                enabled: true
+              system.memory.utilization:
+                enabled: true
+          network: {}
+          paging:
+            metrics:
+              system.paging.usage:
+                enabled: true
+          system:
+            metrics:
+              system.uptime:
+                enabled: true
+      kubelet_stats:
+        auth_type: serviceAccount
+        collection_interval: 15s
+        endpoint: https://${env:OTEL_K8S_NODE_IP}:10250
+        extra_metadata_labels:
+        - container.id
+        - k8s.volume.type
+        insecure_skip_verify: true
+        k8s_api_config:
+          auth_type: serviceAccount
+        metric_groups:
+        - node
+        - pod
+        - volume
+        - container
+        metrics:
+          container.cpu.usage:
+            enabled: true
+          k8s.node.cpu.usage:
+            enabled: true
+          k8s.node.uptime:
+            enabled: true
+          k8s.pod.cpu.usage:
+            enabled: true
+          k8s.pod.uptime:
+            enabled: true
+      otlp:
+        protocols:
+          grpc:
+            endpoint: 0.0.0.0:4317
+          http:
+            endpoint: 0.0.0.0:4318
+      prometheus:
+        config:
+          scrape_configs:
+          - job_name: kubernetes-pods
+            kubernetes_sd_configs:
+            - role: pod
+              selectors:
+              - field: spec.nodeName=${env:OTEL_K8S_NODE_NAME}
+                role: pod
+            relabel_configs:
+            - action: keep
+              regex: true
+              source_labels:
+              - __meta_kubernetes_pod_annotation_prometheus_io_scrape
+            - action: drop
+              regex: true
+              source_labels:
+              - __meta_kubernetes_pod_annotation_prometheus_io_scrape_slow
+            - action: replace
+              regex: (https?)
+              source_labels:
+              - __meta_kubernetes_pod_annotation_prometheus_io_scheme
+              target_label: __scheme__
+            - action: replace
+              regex: (.+)
+              source_labels:
+              - __meta_kubernetes_pod_annotation_prometheus_io_path
+              target_label: __metrics_path__
+            - action: replace
+              regex: ([^:]+)(?::\d+)?;(\d+)
+              replacement: $$1:$$2
+              source_labels:
+              - __address__
+              - __meta_kubernetes_pod_annotation_prometheus_io_port
+              target_label: __address__
+            - action: labelmap
+              regex: __meta_kubernetes_pod_annotation_prometheus_io_param_(.+)
+              replacement: __param_$$1
+            - action: labelmap
+              regex: __meta_kubernetes_pod_label_(.+)
+            - action: replace
+              source_labels:
+              - __meta_kubernetes_namespace
+              target_label: namespace
+            - action: replace
+              source_labels:
+              - __meta_kubernetes_pod_name
+              target_label: pod
+            - action: drop
+              regex: Pending|Succeeded|Failed|Completed
+              source_labels:
+              - __meta_kubernetes_pod_phase
+            - action: replace
+              source_labels:
+              - __meta_kubernetes_pod_label_app_kubernetes_io_name
+              target_label: job
+            scrape_interval: 30s
+          - job_name: node-exporter
+            relabel_configs:
+            - action: labelmap
+              regex: __meta_kubernetes_node_label_(.+)
+            - action: replace
+              regex: (.*)
+              replacement: $$1
+              separator: ;
+              source_labels:
+              - job
+              target_label: __tmp_prometheus_job_name
+            scrape_interval: 30s
+            static_configs:
+            - targets:
+              - ${env:OTEL_K8S_NODE_IP}:9100
+          - authorization:
+              credentials_file: /var/run/secrets/kubernetes.io/serviceaccount/token
+              type: Bearer
+            follow_redirects: true
+            honor_labels: true
+            honor_timestamps: true
+            job_name: kubelet
+            kubernetes_sd_configs:
+            - follow_redirects: true
+              role: node
+              selectors:
+              - field: metadata.name=${env:OTEL_K8S_NODE_NAME}
+                role: node
+            metric_relabel_configs:
+            - action: drop
+              regex: container_cpu_(load_average_10s|system_seconds_total|user_seconds_total)
+              replacement: $$1
+              separator: ;
+              source_labels:
+              - __name__
+            - action: drop
+              regex: container_fs_(io_current|reads_merged_total|sector_reads_total|sector_writes_total|writes_merged_total)
+              replacement: $$1
+              separator: ;
+              source_labels:
+              - __name__
+            - action: drop
+              regex: container_memory_(mapped_file|swap)
+              replacement: $$1
+              separator: ;
+              source_labels:
+              - __name__
+            - action: drop
+              regex: container_(file_descriptors|tasks_state|threads_max)
+              replacement: $$1
+              separator: ;
+              source_labels:
+              - __name__
+            - action: drop
+              regex: container_spec.*
+              replacement: $$1
+              separator: ;
+              source_labels:
+              - __name__
+            - action: drop
+              regex: .+;
+              replacement: $$1
+              separator: ;
+              source_labels:
+              - id
+              - pod
+            metrics_path: /metrics/cadvisor
+            relabel_configs:
+            - action: replace
+              regex: (.*)
+              replacement: $$1
+              separator: ;
+              source_labels:
+              - job
+              target_label: __tmp_prometheus_job_name
+            - action: replace
+              replacement: kubelet
+              target_label: job
+            - action: replace
+              regex: (.*)
+              replacement: $$1
+              separator: ;
+              source_labels:
+              - __meta_kubernetes_node_name
+              target_label: node
+            - action: replace
+              regex: (.*)
+              replacement: https-metrics
+              separator: ;
+              target_label: endpoint
+            - action: replace
+              regex: (.*)
+              replacement: $$1
+              separator: ;
+              source_labels:
+              - __metrics_path__
+              target_label: metrics_path
+            - action: hashmod
+              modulus: 1
+              regex: (.*)
+              replacement: $$1
+              separator: ;
+              source_labels:
+              - __address__
+              target_label: __tmp_hash
+            - action: keep
+              regex: $(SHARD)
+              replacement: $$1
+              separator: ;
+              source_labels:
+              - __tmp_hash
+            scheme: https
+            scrape_interval: 15s
+            scrape_timeout: 10s
+            tls_config:
+              ca_file: /var/run/secrets/kubernetes.io/serviceaccount/ca.crt
+              insecure_skip_verify: true
+    service:
+      pipelines:
+        logs:
+          exporters:
+          - otlp_http
+          processors:
+          - k8s_attributes
+          - resource_detection/env
+          - resource/hostname
+          - batch
+          - resource/global
+          receivers:
+          - otlp
+          - file_log
+        metrics:
+          exporters:
+          - otlp_http
+          processors:
+          - k8s_attributes
+          - resource_detection/env
+          - resource/hostname
+          - batch
+          - resource/global
+          receivers:
+          - prometheus
+          - otlp
+          - host_metrics
+          - kubelet_stats
+        traces:
+          exporters:
+          - otlp_http
+          processors:
+          - k8s_attributes
+          - resource_detection/env
+          - resource/hostname
+          - batch
+          - resource/global
+          receivers:
+          - otlp
+  imagePullPolicy: IfNotPresent
+  upgradeStrategy: automatic
+  terminationGracePeriodSeconds: 30
+  resources:
+    limits:
+      cpu: 200m
+      memory: 500Mi
+    requests:
+      cpu: 100m
+      memory: 250Mi
+  securityContext:
+    {}
+  volumeMounts:
+  - name: varlogpods
+    mountPath: /var/log/pods
+    readOnly: true
+  - name: varlibdockercontainers
+    mountPath: /var/lib/docker/containers
+    readOnly: true
+  - name: hostfs
+    mountPath: /hostfs
+    readOnly: true
+    mountPropagation: HostToContainer
+  env:
+  - name: K8S_NODE_NAME 
+    valueFrom:
+      fieldRef:
+        fieldPath: spec.nodeName
+  - name: OTEL_K8S_NODE_NAME
+    valueFrom:
+      fieldRef:
+        fieldPath: spec.nodeName
+  - name: OTEL_K8S_NODE_IP
+    valueFrom:
+      fieldRef:
+        fieldPath: status.hostIP
+  - name: OTEL_K8S_NAMESPACE
+    valueFrom:
+      fieldRef:
+        apiVersion: v1
+        fieldPath: metadata.namespace
+  - name: OTEL_K8S_POD_NAME
+    valueFrom:
+      fieldRef:
+        apiVersion: v1
+        fieldPath: metadata.name
+  - name: OTEL_K8S_POD_IP
+    valueFrom:
+      fieldRef:
+        apiVersion: v1
+        fieldPath: status.podIP
+  - name: OTEL_RESOURCE_ATTRIBUTES
+    value: "k8s.pod.name=$(OTEL_K8S_POD_NAME),k8s.namespace.name=$(OTEL_K8S_NAMESPACE),k8s.node.name=$(OTEL_K8S_NODE_NAME),host.name=$(OTEL_K8S_NODE_NAME),k8s.node.ip=$(OTEL_K8S_NODE_IP),k8s.pod.ip=$(OTEL_K8S_POD_IP),k8s.cluster.name=unknown_k8s_cluster"
+  
+  volumes:
+  - name: varlogpods
+    hostPath:
+      path: /var/log/pods
+  - name: varlibdockercontainers
+    hostPath:
+      path: /var/lib/docker/containers
+  - name: hostfs
+    hostPath:
+      path: /

--- a/charts/opentelemetry-kube-stack/examples/global-resource-attributes/rendered/hooks.yaml
+++ b/charts/opentelemetry-kube-stack/examples/global-resource-attributes/rendered/hooks.yaml
@@ -1,0 +1,64 @@
+---
+# Source: opentelemetry-kube-stack/templates/hooks.yaml
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: delete-resources-sa
+  annotations:
+    "helm.sh/hook-delete-policy": before-hook-creation,hook-succeeded
+---
+# Source: opentelemetry-kube-stack/templates/hooks.yaml
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: delete-resources-role
+  annotations:
+    "helm.sh/hook-delete-policy": before-hook-creation,hook-succeeded
+rules:
+  - apiGroups:
+      - opentelemetry.io
+    resources:
+      - instrumentations
+      - opampbridges
+      - opentelemetrycollectors
+    verbs:
+      - get
+      - list
+      - delete
+---
+# Source: opentelemetry-kube-stack/templates/hooks.yaml
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: delete-resources-rolebinding
+  annotations:
+    "helm.sh/hook-delete-policy": before-hook-creation,hook-succeeded
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: delete-resources-role
+subjects:
+  - kind: ServiceAccount
+    name: delete-resources-sa
+---
+# Source: opentelemetry-kube-stack/templates/hooks.yaml
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: opentelemetry-kube-stack-pre-delete-job
+  annotations:
+    "helm.sh/hook": pre-delete
+    "helm.sh/hook-delete-policy": hook-succeeded,hook-failed
+spec:
+  template:
+    spec:
+      restartPolicy: Never
+      serviceAccountName: delete-resources-sa
+      containers:
+      - name: delete-resources
+        image: "rancher/kubectl:v1.34.1"
+        args:
+          - "delete"
+          - "instrumentations,opampbridges,opentelemetrycollectors"
+          - "-l"
+          - "helm.sh/chart=opentelemetry-kube-stack-0.20.7"

--- a/charts/opentelemetry-kube-stack/examples/global-resource-attributes/rendered/instrumentation.yaml
+++ b/charts/opentelemetry-kube-stack/examples/global-resource-attributes/rendered/instrumentation.yaml
@@ -1,0 +1,27 @@
+---
+# Source: opentelemetry-kube-stack/templates/instrumentation.yaml
+apiVersion: opentelemetry.io/v1alpha1
+kind: Instrumentation
+metadata:
+  name: example
+  labels:
+    helm.sh/chart: opentelemetry-kube-stack-0.20.7
+    app.kubernetes.io/version: "0.154.0"
+    app.kubernetes.io/managed-by: Helm
+    release: "example"    
+spec:
+  exporter:
+    endpoint: http://collector-collector:4317
+  propagators:
+    - tracecontext
+    - baggage
+    - b3
+    - b3multi
+    - jaeger
+    - xray
+    - ottrace
+  resource:
+    addK8sUIDAttributes: true
+    resourceAttributes:
+      deployment.environment.name: production
+      k8s.cluster.name: my_k8s_cluster

--- a/charts/opentelemetry-kube-stack/examples/global-resource-attributes/rendered/opentelemetry-operator/admission-webhooks/operator-webhook-with-cert-manager.yaml
+++ b/charts/opentelemetry-kube-stack/examples/global-resource-attributes/rendered/opentelemetry-operator/admission-webhooks/operator-webhook-with-cert-manager.yaml
@@ -1,0 +1,192 @@
+---
+# Source: opentelemetry-kube-stack/charts/opentelemetry-operator/templates/admission-webhooks/operator-webhook-with-cert-manager.yaml
+apiVersion: admissionregistration.k8s.io/v1
+kind: MutatingWebhookConfiguration
+metadata:
+  annotations:
+    cert-manager.io/inject-ca-from: default/example-opentelemetry-operator-serving-cert
+  labels:
+    helm.sh/chart: opentelemetry-operator-0.119.0
+    app.kubernetes.io/name: opentelemetry-operator
+    app.kubernetes.io/version: "0.154.0"
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/part-of: opentelemetry-operator
+    app.kubernetes.io/instance: example
+    app.kubernetes.io/component: webhook
+  name: example-opentelemetry-operator-mutation
+webhooks:
+  - admissionReviewVersions:
+      - v1
+    clientConfig:
+      service:
+        name: example-opentelemetry-operator-webhook
+        namespace: default
+        path: /mutate-opentelemetry-io-v1alpha1-instrumentation
+        port: 443
+    failurePolicy: Ignore
+    name: minstrumentation.kb.io
+    rules:
+    - apiGroups:
+        - opentelemetry.io
+      apiVersions:
+        - v1alpha1
+      operations:
+        - CREATE
+        - UPDATE
+      resources:
+        - instrumentations
+      scope: Namespaced
+    sideEffects: None
+    timeoutSeconds: 10
+  - admissionReviewVersions:
+      - v1
+    clientConfig:
+      service:
+        name: example-opentelemetry-operator-webhook
+        namespace: default
+        path: /mutate-opentelemetry-io-v1beta1-opentelemetrycollector
+        port: 443
+    failurePolicy: Ignore
+    name: mopentelemetrycollectorbeta.kb.io
+    rules:
+      - apiGroups:
+          - opentelemetry.io
+        apiVersions:
+          - v1beta1
+        operations:
+          - CREATE
+          - UPDATE
+        resources:
+          - opentelemetrycollectors
+        scope: Namespaced
+    sideEffects: None
+    timeoutSeconds: 10
+  - admissionReviewVersions:
+      - v1
+    clientConfig:
+      service:
+        name: example-opentelemetry-operator-webhook
+        namespace: default
+        path: /mutate-v1-pod
+        port: 443
+    failurePolicy: Ignore
+    name: mpod.kb.io
+    rules:
+      - apiGroups:
+          - ""
+        apiVersions:
+          - v1
+        operations:
+          - CREATE
+        resources:
+          - pods
+        scope: Namespaced
+    sideEffects: None
+    timeoutSeconds: 10
+---
+# Source: opentelemetry-kube-stack/charts/opentelemetry-operator/templates/admission-webhooks/operator-webhook-with-cert-manager.yaml
+apiVersion: admissionregistration.k8s.io/v1
+kind: ValidatingWebhookConfiguration
+metadata:
+  annotations:
+    cert-manager.io/inject-ca-from: default/example-opentelemetry-operator-serving-cert
+  labels:
+    helm.sh/chart: opentelemetry-operator-0.119.0
+    app.kubernetes.io/name: opentelemetry-operator
+    app.kubernetes.io/version: "0.154.0"
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/part-of: opentelemetry-operator
+    app.kubernetes.io/instance: example
+    app.kubernetes.io/component: webhook
+  name: example-opentelemetry-operator-validation
+webhooks:
+  - admissionReviewVersions:
+      - v1
+    clientConfig:
+      service:
+        name: example-opentelemetry-operator-webhook
+        namespace: default
+        path: /validate-opentelemetry-io-v1alpha1-instrumentation
+        port: 443
+    failurePolicy: Ignore
+    name: vinstrumentationcreateupdate.kb.io
+    rules:
+    - apiGroups:
+        - opentelemetry.io
+      apiVersions:
+        - v1alpha1
+      operations:
+        - CREATE
+        - UPDATE
+      resources:
+        - instrumentations
+      scope: Namespaced
+    sideEffects: None
+    timeoutSeconds: 10
+  - admissionReviewVersions:
+      - v1
+    clientConfig:
+      service:
+        name: example-opentelemetry-operator-webhook
+        namespace: default
+        path: /validate-opentelemetry-io-v1alpha1-instrumentation
+        port: 443
+    failurePolicy: Ignore
+    name: vinstrumentationdelete.kb.io
+    rules:
+      - apiGroups:
+          - opentelemetry.io
+        apiVersions:
+          - v1alpha1
+        operations:
+          - DELETE
+        resources:
+          - instrumentations
+        scope: Namespaced
+    sideEffects: None
+    timeoutSeconds: 10
+  - admissionReviewVersions:
+      - v1
+    clientConfig:
+      service:
+        name: example-opentelemetry-operator-webhook
+        namespace: default
+        path: /validate-opentelemetry-io-v1beta1-opentelemetrycollector
+        port: 443
+    failurePolicy: Ignore
+    name: vopentelemetrycollectorcreateupdatebeta.kb.io
+    rules:
+      - apiGroups:
+          - opentelemetry.io
+        apiVersions:
+          - v1beta1
+        operations:
+          - CREATE
+          - UPDATE
+        resources:
+          - opentelemetrycollectors
+        scope: Namespaced
+    sideEffects: None
+    timeoutSeconds: 10
+  - admissionReviewVersions:
+      - v1
+    clientConfig:
+      service:
+        name: example-opentelemetry-operator-webhook
+        namespace: default
+        path: /validate-opentelemetry-io-v1beta1-opentelemetrycollector
+        port: 443
+    failurePolicy: Ignore
+    name: vopentelemetrycollectordeletebeta.kb.io
+    rules:
+      - apiGroups:
+          - opentelemetry.io
+        apiVersions:
+          - v1beta1
+        operations:
+          - DELETE
+        resources:
+          - opentelemetrycollectors
+        scope: Namespaced
+    sideEffects: None
+    timeoutSeconds: 10

--- a/charts/opentelemetry-kube-stack/examples/global-resource-attributes/rendered/opentelemetry-operator/admission-webhooks/operator-webhook.yaml
+++ b/charts/opentelemetry-kube-stack/examples/global-resource-attributes/rendered/opentelemetry-operator/admission-webhooks/operator-webhook.yaml
@@ -1,0 +1,6 @@
+---
+# Source: opentelemetry-kube-stack/charts/opentelemetry-operator/templates/admission-webhooks/operator-webhook.yaml
+---
+---
+# Source: opentelemetry-kube-stack/charts/opentelemetry-operator/templates/admission-webhooks/operator-webhook.yaml
+---

--- a/charts/opentelemetry-kube-stack/examples/global-resource-attributes/rendered/opentelemetry-operator/certmanager.yaml
+++ b/charts/opentelemetry-kube-stack/examples/global-resource-attributes/rendered/opentelemetry-operator/certmanager.yaml
@@ -1,0 +1,43 @@
+---
+# Source: opentelemetry-kube-stack/charts/opentelemetry-operator/templates/certmanager.yaml
+apiVersion: cert-manager.io/v1
+kind: Certificate
+metadata:
+  labels:
+    helm.sh/chart: opentelemetry-operator-0.119.0
+    app.kubernetes.io/name: opentelemetry-operator
+    app.kubernetes.io/version: "0.154.0"
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/part-of: opentelemetry-operator
+    app.kubernetes.io/instance: example
+    app.kubernetes.io/component: webhook
+  name: example-opentelemetry-operator-serving-cert
+  namespace: default
+spec:
+  dnsNames:
+    - example-opentelemetry-operator-webhook.default.svc
+    - example-opentelemetry-operator-webhook.default.svc.cluster.local
+  issuerRef:
+    kind: Issuer
+    name: example-opentelemetry-operator-selfsigned-issuer
+  secretName: example-opentelemetry-operator-controller-manager-service-cert
+  subject:
+    organizationalUnits:
+      - example-opentelemetry-operator
+---
+# Source: opentelemetry-kube-stack/charts/opentelemetry-operator/templates/certmanager.yaml
+apiVersion: cert-manager.io/v1
+kind: Issuer
+metadata:
+  labels:
+    helm.sh/chart: opentelemetry-operator-0.119.0
+    app.kubernetes.io/name: opentelemetry-operator
+    app.kubernetes.io/version: "0.154.0"
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/part-of: opentelemetry-operator
+    app.kubernetes.io/instance: example
+    app.kubernetes.io/component: webhook
+  name: example-opentelemetry-operator-selfsigned-issuer
+  namespace: default
+spec:
+  selfSigned: {}

--- a/charts/opentelemetry-kube-stack/examples/global-resource-attributes/rendered/opentelemetry-operator/clusterrole.yaml
+++ b/charts/opentelemetry-kube-stack/examples/global-resource-attributes/rendered/opentelemetry-operator/clusterrole.yaml
@@ -1,0 +1,418 @@
+---
+# Source: opentelemetry-kube-stack/charts/opentelemetry-operator/templates/clusterrole.yaml
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  labels:
+    helm.sh/chart: opentelemetry-operator-0.119.0
+    app.kubernetes.io/name: opentelemetry-operator
+    app.kubernetes.io/version: "0.154.0"
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/part-of: opentelemetry-operator
+    app.kubernetes.io/instance: example
+    app.kubernetes.io/component: controller-manager
+  name: example-opentelemetry-operator-manager
+rules:
+  - apiGroups:
+      - ""
+    resources:
+      - configmaps
+      - persistentvolumeclaims
+      - persistentvolumes
+      - pods
+      - serviceaccounts
+      - services
+    verbs:
+      - create
+      - delete
+      - get
+      - list
+      - patch
+      - update
+      - watch
+  - apiGroups:
+      - ""
+    resources:
+      - events
+    verbs:
+      - create
+      - get
+      - list
+      - patch
+      - watch
+  - apiGroups:
+      - ""
+    resources:
+      - namespaces
+    verbs:
+      - list
+      - watch
+  - apiGroups:
+      - ""
+    resources:
+      - namespaces/status
+    verbs:
+      - get
+      - list
+      - watch
+  - apiGroups:
+      - ""
+    resources:
+      - nodes/spec
+    verbs:
+      - get
+      - list
+      - watch
+  - apiGroups:
+      - ""
+    resources:
+      - pods/status
+    verbs:
+      - get
+      - list
+      - watch
+  - apiGroups:
+      - ""
+    resources:
+      - replicationcontrollers
+    verbs:
+      - get
+      - list
+      - watch
+  - apiGroups:
+      - ""
+    resources:
+      - replicationcontrollers/status
+    verbs:
+      - get
+      - list
+      - watch
+  - apiGroups:
+      - ""
+    resources:
+      - resourcequotas
+    verbs:
+      - get
+      - list
+      - watch
+  - apiGroups:
+      - apps
+    resources:
+      - daemonsets
+      - deployments
+      - statefulsets
+    verbs:
+      - create
+      - delete
+      - get
+      - list
+      - patch
+      - update
+      - watch
+  - apiGroups:
+      - apps
+      - extensions
+    resources:
+      - replicasets
+    verbs:
+      - get
+      - list
+      - watch
+  - apiGroups:
+      - extensions
+    resources:
+      - daemonsets
+    verbs:
+      - get
+      - list
+      - watch
+  - apiGroups:
+      - extensions
+    resources:
+      - deployments
+    verbs:
+      - get
+      - list
+      - watch
+  - apiGroups:
+      - autoscaling
+    resources:
+      - horizontalpodautoscalers
+    verbs:
+      - create
+      - delete
+      - get
+      - list
+      - patch
+      - update
+      - watch
+  - apiGroups:
+      - batch
+    resources:
+      - jobs
+    verbs:
+      - get
+      - list
+      - watch
+  - apiGroups:
+      - batch
+    resources:
+      - cronjobs
+    verbs:
+      - get
+      - list
+      - watch
+  - apiGroups:
+      - ""
+    resources:
+      - nodes/proxy
+    verbs:
+      - get
+  - apiGroups:
+      - ""
+    resources:
+      - nodes/stats
+    verbs:
+      - get
+  - apiGroups:
+      - config.openshift.io
+    resources:
+      - infrastructures
+      - infrastructures/status
+    verbs:
+      - get
+      - list
+      - watch
+  - apiGroups:
+      - operators.coreos.com
+    resources:
+      - clusterserviceversions
+    verbs:
+      - get
+      - list
+      - patch
+      - update
+      - watch
+  - apiGroups:
+      - coordination.k8s.io
+    resources:
+      - leases
+    verbs:
+      - create
+      - get
+      - list
+      - update
+  - apiGroups:
+      - discovery.k8s.io
+    resources:
+      - endpointslices
+    verbs:
+      - get
+      - list
+  - apiGroups:
+      - events.k8s.io
+    resources:
+      - events
+    verbs:
+      - create
+      - list
+      - patch
+      - watch
+  - apiGroups:
+      - gateway.networking.k8s.io
+    resources:
+      - httproutes
+    verbs:
+      - create
+      - delete
+      - get
+      - list
+      - patch
+      - update
+      - watch
+  - apiGroups:
+      - monitoring.coreos.com
+    resources:
+      - podmonitors
+      - servicemonitors
+    verbs:
+      - create
+      - delete
+      - get
+      - list
+      - patch
+      - update
+      - watch
+  - apiGroups:
+      - networking.k8s.io
+    resources:
+      - ingresses
+      - networkpolicies
+    verbs:
+      - create
+      - delete
+      - get
+      - list
+      - patch
+      - update
+      - watch
+  - apiGroups:
+      - opentelemetry.io
+    resources:
+      - instrumentations
+    verbs:
+      - get
+      - list
+      - patch
+      - update
+      - watch
+  - apiGroups:
+      - opentelemetry.io
+    resources:
+      - opampbridges
+    verbs:
+      - create
+      - delete
+      - get
+      - list
+      - patch
+      - update
+      - watch
+  - apiGroups:
+      - opentelemetry.io
+    resources:
+      - opampbridges/finalizers
+    verbs:
+      - update
+  - apiGroups:
+      - opentelemetry.io
+    resources:
+      - opampbridges/status
+    verbs:
+      - get
+      - patch
+      - update
+  - apiGroups:
+      - opentelemetry.io
+    resources:
+      - opentelemetrycollectors
+    verbs:
+      - get
+      - list
+      - patch
+      - update
+      - watch
+  - apiGroups:
+      - opentelemetry.io
+    resources:
+      - opentelemetrycollectors/finalizers
+    verbs:
+      - get
+      - patch
+      - update
+  - apiGroups:
+      - opentelemetry.io
+    resources:
+      - opentelemetrycollectors/status
+    verbs:
+      - get
+      - patch
+      - update
+  - apiGroups:
+      - policy
+    resources:
+      - poddisruptionbudgets
+    verbs:
+      - create
+      - delete
+      - get
+      - list
+      - patch
+      - update
+      - watch
+  - apiGroups:
+      - route.openshift.io
+    resources:
+      - routes
+      - routes/custom-host
+    verbs:
+      - create
+      - delete
+      - get
+      - list
+      - patch
+      - update
+      - watch
+  - apiGroups:
+    - opentelemetry.io
+    resources:
+      - targetallocators
+    verbs:
+      - create
+      - delete
+      - get
+      - list
+      - patch
+      - update
+      - watch
+  - apiGroups:
+    - opentelemetry.io
+    resources:
+    - targetallocators/status
+    verbs:
+    - get
+    - patch
+    - update
+  - apiGroups:
+    - opentelemetry.io
+    resources:
+    - targetallocators/finalizers
+    verbs:
+    - get
+    - patch
+    - update
+  - apiGroups:
+      - cert-manager.io
+    resources:
+      - issuers
+      - certificaterequests
+      - certificates
+    verbs:
+      - create
+      - get
+      - list
+      - watch
+      - update
+      - patch
+      - delete
+  - apiGroups:
+      - authentication.k8s.io
+    resources:
+      - tokenreviews
+    verbs:
+      - create
+  - apiGroups:
+      - authorization.k8s.io
+    resources:
+      - subjectaccessreviews
+    verbs:
+      - create
+---
+# Source: opentelemetry-kube-stack/charts/opentelemetry-operator/templates/clusterrole.yaml
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  labels:
+    helm.sh/chart: opentelemetry-operator-0.119.0
+    app.kubernetes.io/name: opentelemetry-operator
+    app.kubernetes.io/version: "0.154.0"
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/part-of: opentelemetry-operator
+    app.kubernetes.io/instance: example
+    app.kubernetes.io/component: controller-manager
+  name: example-opentelemetry-operator-metrics
+rules:
+  - nonResourceURLs:
+      - /metrics
+    verbs:
+      - get

--- a/charts/opentelemetry-kube-stack/examples/global-resource-attributes/rendered/opentelemetry-operator/clusterrolebinding.yaml
+++ b/charts/opentelemetry-kube-stack/examples/global-resource-attributes/rendered/opentelemetry-operator/clusterrolebinding.yaml
@@ -1,0 +1,22 @@
+---
+# Source: opentelemetry-kube-stack/charts/opentelemetry-operator/templates/clusterrolebinding.yaml
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  labels:
+    helm.sh/chart: opentelemetry-operator-0.119.0
+    app.kubernetes.io/name: opentelemetry-operator
+    app.kubernetes.io/version: "0.154.0"
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/part-of: opentelemetry-operator
+    app.kubernetes.io/instance: example
+    app.kubernetes.io/component: controller-manager
+  name: example-opentelemetry-operator-manager
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: example-opentelemetry-operator-manager
+subjects:
+  - kind: ServiceAccount
+    name: opentelemetry-operator
+    namespace: default

--- a/charts/opentelemetry-kube-stack/examples/global-resource-attributes/rendered/opentelemetry-operator/deployment.yaml
+++ b/charts/opentelemetry-kube-stack/examples/global-resource-attributes/rendered/opentelemetry-operator/deployment.yaml
@@ -1,0 +1,104 @@
+---
+# Source: opentelemetry-kube-stack/charts/opentelemetry-operator/templates/deployment.yaml
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  labels:
+    helm.sh/chart: opentelemetry-operator-0.119.0
+    app.kubernetes.io/name: opentelemetry-operator
+    app.kubernetes.io/version: "0.154.0"
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/part-of: opentelemetry-operator
+    app.kubernetes.io/instance: example
+    app.kubernetes.io/component: controller-manager
+  name: example-opentelemetry-operator
+  namespace: default
+spec:
+  replicas: 1
+  revisionHistoryLimit: 10
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: opentelemetry-operator
+      app.kubernetes.io/component: controller-manager
+  template:
+    metadata:
+      annotations:
+        kubectl.kubernetes.io/default-container: manager
+      labels:
+        helm.sh/chart: opentelemetry-operator-0.119.0
+        app.kubernetes.io/name: opentelemetry-operator
+        app.kubernetes.io/version: "0.154.0"
+        app.kubernetes.io/managed-by: Helm
+        app.kubernetes.io/part-of: opentelemetry-operator
+        app.kubernetes.io/instance: example
+        app.kubernetes.io/component: controller-manager
+    spec:
+      automountServiceAccountToken: true
+      hostNetwork: false
+      containers:
+        - args:
+            - --metrics-addr=0.0.0.0:8443
+            - --metrics-secure=true
+            - --enable-leader-election
+            - --health-probe-addr=:8081
+            - --webhook-port=9443
+            - --collector-image=otel/opentelemetry-collector-k8s:0.154.0
+          command:
+            - /manager
+          env:
+            - name: SERVICE_ACCOUNT_NAME
+              valueFrom:
+                fieldRef:
+                  fieldPath: spec.serviceAccountName
+            - name: ENABLE_WEBHOOKS
+              value: "true"
+          image: "ghcr.io/open-telemetry/opentelemetry-operator/opentelemetry-operator:0.154.0"
+          name: manager
+          imagePullPolicy: IfNotPresent
+          ports:
+            - containerPort: 8443
+              name: metrics
+              protocol: TCP
+            - containerPort: 9443
+              name: webhook-server
+              protocol: TCP
+          livenessProbe:
+            httpGet:
+              path: /healthz
+              port: 8081
+            initialDelaySeconds: 15
+            periodSeconds: 20
+          readinessProbe:
+            httpGet:
+              path: /readyz
+              port: 8081
+            initialDelaySeconds: 5
+            periodSeconds: 10
+          resources: 
+            {}
+          volumeMounts:
+            - mountPath: /tmp/k8s-webhook-server/serving-certs
+              name: cert
+              readOnly: true
+          securityContext: 
+            allowPrivilegeEscalation: false
+            capabilities:
+              drop:
+              - ALL
+            runAsNonRoot: true
+            seccompProfile:
+              type: RuntimeDefault
+      nodeSelector: 
+        kubernetes.io/os: linux
+      serviceAccountName: opentelemetry-operator
+      terminationGracePeriodSeconds: 10
+      volumes:
+        - name: cert
+          secret:
+            defaultMode: 420
+            secretName: example-opentelemetry-operator-controller-manager-service-cert
+      securityContext:
+        fsGroup: 65532
+        runAsGroup: 65532
+        runAsNonRoot: true
+        runAsUser: 65532

--- a/charts/opentelemetry-kube-stack/examples/global-resource-attributes/rendered/opentelemetry-operator/role.yaml
+++ b/charts/opentelemetry-kube-stack/examples/global-resource-attributes/rendered/opentelemetry-operator/role.yaml
@@ -1,0 +1,199 @@
+---
+# Source: opentelemetry-kube-stack/charts/opentelemetry-operator/templates/role.yaml
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  labels:
+    helm.sh/chart: opentelemetry-operator-0.119.0
+    app.kubernetes.io/name: opentelemetry-operator
+    app.kubernetes.io/version: "0.154.0"
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/part-of: opentelemetry-operator
+    app.kubernetes.io/instance: example
+    app.kubernetes.io/component: controller-manager
+  name: example-opentelemetry-operator-leader-election
+  namespace: default
+rules:
+  - apiGroups:
+      - ""
+    resources:
+      - configmaps
+      - pods
+      - serviceaccounts
+      - services
+    verbs:
+      - create
+      - delete
+      - get
+      - list
+      - patch
+      - update
+      - watch
+  - apiGroups:
+      - ""
+    resources:
+      - events
+    verbs:
+      - create
+      - patch
+  - apiGroups:
+      - ""
+    resources:
+      - namespaces
+      - secrets
+    verbs:
+      - get
+      - list
+      - watch
+  - apiGroups:
+      - apps
+    resources:
+      - daemonsets
+      - deployments
+      - statefulsets
+    verbs:
+      - create
+      - delete
+      - get
+      - list
+      - patch
+      - update
+      - watch
+  - apiGroups:
+      - apps
+    resources:
+      - replicasets
+    verbs:
+      - get
+      - list
+      - watch
+  - apiGroups:
+      - autoscaling
+    resources:
+      - horizontalpodautoscalers
+    verbs:
+      - create
+      - delete
+      - get
+      - list
+      - patch
+      - update
+      - watch
+  - apiGroups:
+      - batch
+    resources:
+      - jobs
+    verbs:
+      - get
+      - list
+      - watch
+  - apiGroups:
+      - config.openshift.io
+    resources:
+      - infrastructures
+      - infrastructures/status
+    verbs:
+      - get
+      - list
+      - watch
+  - apiGroups:
+      - coordination.k8s.io
+    resources:
+      - leases
+    verbs:
+      - create
+      - get
+      - list
+      - update
+  - apiGroups:
+      - monitoring.coreos.com
+    resources:
+      - podmonitors
+      - servicemonitors
+    verbs:
+      - create
+      - delete
+      - get
+      - list
+      - patch
+      - update
+      - watch
+  - apiGroups:
+      - networking.k8s.io
+    resources:
+      - ingresses
+    verbs:
+      - create
+      - delete
+      - get
+      - list
+      - patch
+      - update
+      - watch
+  - apiGroups:
+      - opentelemetry.io
+    resources:
+      - instrumentations
+      - opentelemetrycollectors
+    verbs:
+      - get
+      - list
+      - patch
+      - update
+      - watch
+  - apiGroups:
+      - opentelemetry.io
+    resources:
+      - opampbridges
+      - targetallocators
+    verbs:
+      - create
+      - delete
+      - get
+      - list
+      - patch
+      - update
+      - watch
+  - apiGroups:
+      - opentelemetry.io
+    resources:
+      - opampbridges/finalizers
+    verbs:
+      - update
+  - apiGroups:
+      - opentelemetry.io
+    resources:
+      - opampbridges/status
+      - opentelemetrycollectors/finalizers
+      - opentelemetrycollectors/status
+      - targetallocators/status
+      - targetallocators/finalizers
+    verbs:
+      - get
+      - patch
+      - update
+  - apiGroups:
+      - policy
+    resources:
+      - poddisruptionbudgets
+    verbs:
+      - create
+      - delete
+      - get
+      - list
+      - patch
+      - update
+      - watch
+  - apiGroups:
+      - route.openshift.io
+    resources:
+      - routes
+      - routes/custom-host
+    verbs:
+      - create
+      - delete
+      - get
+      - list
+      - patch
+      - update
+      - watch

--- a/charts/opentelemetry-kube-stack/examples/global-resource-attributes/rendered/opentelemetry-operator/rolebinding.yaml
+++ b/charts/opentelemetry-kube-stack/examples/global-resource-attributes/rendered/opentelemetry-operator/rolebinding.yaml
@@ -1,0 +1,23 @@
+---
+# Source: opentelemetry-kube-stack/charts/opentelemetry-operator/templates/rolebinding.yaml
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  labels:
+    helm.sh/chart: opentelemetry-operator-0.119.0
+    app.kubernetes.io/name: opentelemetry-operator
+    app.kubernetes.io/version: "0.154.0"
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/part-of: opentelemetry-operator
+    app.kubernetes.io/instance: example
+    app.kubernetes.io/component: controller-manager
+  name: example-opentelemetry-operator-leader-election
+  namespace: default
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: example-opentelemetry-operator-leader-election
+subjects:
+  - kind: ServiceAccount
+    name: opentelemetry-operator
+    namespace: default

--- a/charts/opentelemetry-kube-stack/examples/global-resource-attributes/rendered/opentelemetry-operator/service.yaml
+++ b/charts/opentelemetry-kube-stack/examples/global-resource-attributes/rendered/opentelemetry-operator/service.yaml
@@ -1,0 +1,47 @@
+---
+# Source: opentelemetry-kube-stack/charts/opentelemetry-operator/templates/service.yaml
+apiVersion: v1
+kind: Service
+metadata:
+  labels:
+    helm.sh/chart: opentelemetry-operator-0.119.0
+    app.kubernetes.io/name: opentelemetry-operator
+    app.kubernetes.io/version: "0.154.0"
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/part-of: opentelemetry-operator
+    app.kubernetes.io/instance: example
+    app.kubernetes.io/component: controller-manager
+  name: example-opentelemetry-operator
+  namespace: default
+spec:
+  ports:
+    - name: metrics
+      port: 8443
+      protocol: TCP
+      targetPort: metrics
+  selector:
+      app.kubernetes.io/name: opentelemetry-operator
+      app.kubernetes.io/component: controller-manager
+---
+# Source: opentelemetry-kube-stack/charts/opentelemetry-operator/templates/service.yaml
+apiVersion: v1
+kind: Service
+metadata:
+  labels:
+    helm.sh/chart: opentelemetry-operator-0.119.0
+    app.kubernetes.io/name: opentelemetry-operator
+    app.kubernetes.io/version: "0.154.0"
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/part-of: opentelemetry-operator
+    app.kubernetes.io/instance: example
+    app.kubernetes.io/component: controller-manager
+  name: example-opentelemetry-operator-webhook
+  namespace: default
+spec:
+  ports:
+    - port: 443
+      protocol: TCP
+      targetPort: webhook-server
+  selector:
+      app.kubernetes.io/name: opentelemetry-operator
+      app.kubernetes.io/component: controller-manager

--- a/charts/opentelemetry-kube-stack/examples/global-resource-attributes/rendered/opentelemetry-operator/serviceaccount.yaml
+++ b/charts/opentelemetry-kube-stack/examples/global-resource-attributes/rendered/opentelemetry-operator/serviceaccount.yaml
@@ -1,0 +1,16 @@
+---
+# Source: opentelemetry-kube-stack/charts/opentelemetry-operator/templates/serviceaccount.yaml
+apiVersion: v1
+kind: ServiceAccount
+automountServiceAccountToken: true
+metadata:
+  name: opentelemetry-operator
+  namespace: default
+  labels:
+    helm.sh/chart: opentelemetry-operator-0.119.0
+    app.kubernetes.io/name: opentelemetry-operator
+    app.kubernetes.io/version: "0.154.0"
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/part-of: opentelemetry-operator
+    app.kubernetes.io/instance: example
+    app.kubernetes.io/component: controller-manager

--- a/charts/opentelemetry-kube-stack/examples/global-resource-attributes/rendered/opentelemetry-operator/tests/test-certmanager-connection.yaml
+++ b/charts/opentelemetry-kube-stack/examples/global-resource-attributes/rendered/opentelemetry-operator/tests/test-certmanager-connection.yaml
@@ -1,0 +1,59 @@
+---
+# Source: opentelemetry-kube-stack/charts/opentelemetry-operator/templates/tests/test-certmanager-connection.yaml
+apiVersion: v1
+kind: Pod
+metadata:
+  name: "example-opentelemetry-operator-cert-manager"
+  namespace: default
+  labels:
+    helm.sh/chart: opentelemetry-operator-0.119.0
+    app.kubernetes.io/name: opentelemetry-operator
+    app.kubernetes.io/version: "0.154.0"
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/part-of: opentelemetry-operator
+    app.kubernetes.io/instance: example
+    app.kubernetes.io/component: webhook
+  annotations:
+    "helm.sh/hook": test
+spec:
+  containers:
+    - name: wget
+      image: "busybox:latest"
+      env:
+        - name: CERT_MANAGER_CLUSTERIP
+          value: "cert-manager-webhook.cert-manager"
+        - name: CERT_MANAGER_PORT
+          value: "443"
+      command:
+        - sh
+        - -c
+        # The following shell script tests if the cert-manager service is up. If the service is up, when we try
+        # to wget its exposed port, we will get an HTTP error 400.
+        - |
+          i=0
+          while [ "$i" -lt 30 ]; do
+            wget_output=$(wget -q "$CERT_MANAGER_CLUSTERIP:$CERT_MANAGER_PORT" 2>&1 || true)
+            if [ "$wget_output" = "wget: server returned error: HTTP/1.0 400 Bad Request" ]; then
+              exit 0
+            fi
+            i=$((i + 1))
+            sleep 2
+          done
+          echo "$wget_output"
+          exit 1
+      securityContext: 
+            allowPrivilegeEscalation: false
+            capabilities:
+              drop:
+              - ALL
+            runAsNonRoot: true
+            seccompProfile:
+              type: RuntimeDefault
+  restartPolicy: Never
+  nodeSelector: 
+    kubernetes.io/os: linux
+  securityContext:
+    fsGroup: 65532
+    runAsGroup: 65532
+    runAsNonRoot: true
+    runAsUser: 65532

--- a/charts/opentelemetry-kube-stack/examples/global-resource-attributes/rendered/opentelemetry-operator/tests/test-service-connection.yaml
+++ b/charts/opentelemetry-kube-stack/examples/global-resource-attributes/rendered/opentelemetry-operator/tests/test-service-connection.yaml
@@ -1,0 +1,118 @@
+---
+# Source: opentelemetry-kube-stack/charts/opentelemetry-operator/templates/tests/test-service-connection.yaml
+apiVersion: v1
+kind: Pod
+metadata:
+  name: "example-opentelemetry-operator-metrics-test"
+  namespace: default
+  labels:
+    helm.sh/chart: opentelemetry-operator-0.119.0
+    app.kubernetes.io/name: opentelemetry-operator
+    app.kubernetes.io/version: "0.154.0"
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/part-of: opentelemetry-operator
+    app.kubernetes.io/instance: example
+    app.kubernetes.io/component: controller-manager
+  annotations:
+    "helm.sh/hook": test
+spec:
+  containers:
+    - name: wget
+      image: "busybox:latest"
+      env:
+        - name: MANAGER_METRICS_SERVICE_CLUSTERIP
+          value: "example-opentelemetry-operator"
+        - name: MANAGER_METRICS_SERVICE_PORT
+          value: "8443"
+      command:
+        - sh
+        - -c
+        # The following shell script tests if the controller-manager-metrics-service is up.
+        # If the service is up, when we try to wget its exposed port, we will get an HTTP error 400.
+        - |
+          i=0
+          while [ "$i" -lt 30 ]; do
+            wget_output=$(wget -q "$MANAGER_METRICS_SERVICE_CLUSTERIP:$MANAGER_METRICS_SERVICE_PORT" 2>&1 || true)
+            if [ "$wget_output" = "wget: server returned error: HTTP/1.0 400 Bad Request" ]; then
+              exit 0
+            fi
+            i=$((i + 1))
+            sleep 2
+          done
+          echo "$wget_output"
+          exit 1
+      securityContext: 
+            allowPrivilegeEscalation: false
+            capabilities:
+              drop:
+              - ALL
+            runAsNonRoot: true
+            seccompProfile:
+              type: RuntimeDefault
+  restartPolicy: Never
+  nodeSelector: 
+    kubernetes.io/os: linux
+  securityContext:
+    fsGroup: 65532
+    runAsGroup: 65532
+    runAsNonRoot: true
+    runAsUser: 65532
+---
+# Source: opentelemetry-kube-stack/charts/opentelemetry-operator/templates/tests/test-service-connection.yaml
+apiVersion: v1
+kind: Pod
+metadata:
+  name: "example-opentelemetry-operator-webhook-test"
+  namespace: default
+  labels:
+    helm.sh/chart: opentelemetry-operator-0.119.0
+    app.kubernetes.io/name: opentelemetry-operator
+    app.kubernetes.io/version: "0.154.0"
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/part-of: opentelemetry-operator
+    app.kubernetes.io/instance: example
+    app.kubernetes.io/component: controller-manager
+  annotations:
+    "helm.sh/hook": test
+spec:
+  containers:
+    - name: wget
+      image: "busybox:latest"
+      env:
+        - name: WEBHOOK_SERVICE_CLUSTERIP
+          value: "example-opentelemetry-operator-webhook"
+        - name: WEBHOOK_SERVICE_PORT
+          value: "443"
+      command:
+        - sh
+        - -c
+        # The following shell script tests if the webhook service is up. If the service is up, when we try
+        # to wget its exposed port, we will get an HTTP error 400.
+        - |
+          i=0
+          while [ "$i" -lt 30 ]; do
+            wget_output=$(wget -q "$WEBHOOK_SERVICE_CLUSTERIP:$WEBHOOK_SERVICE_PORT" 2>&1 || true)
+            if [ "$wget_output" = "wget: server returned error: HTTP/1.0 400 Bad Request" ]; then
+              exit 0
+            fi
+            i=$((i + 1))
+            sleep 2
+          done
+          echo "$wget_output"
+          exit 1
+      securityContext: 
+            allowPrivilegeEscalation: false
+            capabilities:
+              drop:
+              - ALL
+            runAsNonRoot: true
+            seccompProfile:
+              type: RuntimeDefault
+  restartPolicy: Never
+  nodeSelector: 
+    kubernetes.io/os: linux
+  securityContext:
+    fsGroup: 65532
+    runAsGroup: 65532
+    runAsNonRoot: true
+    runAsUser: 65532

--- a/charts/opentelemetry-kube-stack/examples/global-resource-attributes/values.yaml
+++ b/charts/opentelemetry-kube-stack/examples/global-resource-attributes/values.yaml
@@ -1,0 +1,52 @@
+
+resourceAttributes:
+  deployment.environment.name: "production"
+  k8s.cluster.name: "my_k8s_cluster"
+
+defaultCRConfig:
+  config:
+    exporters:
+      otlp_http:
+        endpoint: "https://otlp.example.com:4318"
+collectors:
+  daemon:
+    presets:
+      clusterMetrics:
+        enabled: false
+      kubernetesEvents:
+        enabled: false
+    config:
+      service:
+        pipelines:
+          logs:
+            exporters:
+            - otlp_http
+          metrics:
+            exporters:
+              - otlp_http
+          traces:
+            exporters:
+              - otlp_http
+  cluster:
+    enabled: true
+    presets:
+      kubernetesAttributes:
+        enabled: true
+      clusterMetrics:
+        enabled: true
+      kubernetesEvents:
+        enabled: true
+    config:
+      service:
+        pipelines:
+          logs:
+            exporters:
+            - otlp_http
+          metrics:
+            exporters:
+              - otlp_http
+          traces:
+            exporters:
+              - otlp_http
+instrumentation:
+  enabled: true

--- a/charts/opentelemetry-kube-stack/examples/global-resource-attributes/values.yaml
+++ b/charts/opentelemetry-kube-stack/examples/global-resource-attributes/values.yaml
@@ -1,4 +1,3 @@
-
 resourceAttributes:
   deployment.environment.name: "production"
   k8s.cluster.name: "my_k8s_cluster"
@@ -20,7 +19,7 @@ collectors:
         pipelines:
           logs:
             exporters:
-            - otlp_http
+              - otlp_http
           metrics:
             exporters:
               - otlp_http
@@ -41,7 +40,7 @@ collectors:
         pipelines:
           logs:
             exporters:
-            - otlp_http
+              - otlp_http
           metrics:
             exporters:
               - otlp_http

--- a/charts/opentelemetry-kube-stack/examples/isolated-multicollector-deployment/rendered/collector.yaml
+++ b/charts/opentelemetry-kube-stack/examples/isolated-multicollector-deployment/rendered/collector.yaml
@@ -6,7 +6,7 @@ metadata:
   name: agent
   namespace: default
   labels:
-    helm.sh/chart: opentelemetry-kube-stack-0.20.6
+    helm.sh/chart: opentelemetry-kube-stack-0.20.7
     app.kubernetes.io/version: "0.154.0"
     app.kubernetes.io/managed-by: Helm
     release: "example"        
@@ -232,7 +232,7 @@ metadata:
   name: gateway
   namespace: default
   labels:
-    helm.sh/chart: opentelemetry-kube-stack-0.20.6
+    helm.sh/chart: opentelemetry-kube-stack-0.20.7
     app.kubernetes.io/version: "0.154.0"
     app.kubernetes.io/managed-by: Helm
     release: "example"        
@@ -365,7 +365,7 @@ metadata:
   name: ingress
   namespace: default
   labels:
-    helm.sh/chart: opentelemetry-kube-stack-0.20.6
+    helm.sh/chart: opentelemetry-kube-stack-0.20.7
     app.kubernetes.io/version: "0.154.0"
     app.kubernetes.io/managed-by: Helm
     release: "example"        

--- a/charts/opentelemetry-kube-stack/examples/isolated-multicollector-deployment/rendered/hooks.yaml
+++ b/charts/opentelemetry-kube-stack/examples/isolated-multicollector-deployment/rendered/hooks.yaml
@@ -61,4 +61,4 @@ spec:
           - "delete"
           - "instrumentations,opampbridges,opentelemetrycollectors"
           - "-l"
-          - "helm.sh/chart=opentelemetry-kube-stack-0.20.6"
+          - "helm.sh/chart=opentelemetry-kube-stack-0.20.7"

--- a/charts/opentelemetry-kube-stack/examples/no-leader-election-extension/rendered/collector.yaml
+++ b/charts/opentelemetry-kube-stack/examples/no-leader-election-extension/rendered/collector.yaml
@@ -6,7 +6,7 @@ metadata:
   name: example-cluster-stats
   namespace: default
   labels:
-    helm.sh/chart: opentelemetry-kube-stack-0.20.6
+    helm.sh/chart: opentelemetry-kube-stack-0.20.7
     app.kubernetes.io/version: "0.154.0"
     app.kubernetes.io/managed-by: Helm
     release: "example"        
@@ -173,7 +173,7 @@ metadata:
   name: example-daemon
   namespace: default
   labels:
-    helm.sh/chart: opentelemetry-kube-stack-0.20.6
+    helm.sh/chart: opentelemetry-kube-stack-0.20.7
     app.kubernetes.io/version: "0.154.0"
     app.kubernetes.io/managed-by: Helm
     release: "example"        

--- a/charts/opentelemetry-kube-stack/examples/no-leader-election-extension/rendered/hooks.yaml
+++ b/charts/opentelemetry-kube-stack/examples/no-leader-election-extension/rendered/hooks.yaml
@@ -61,4 +61,4 @@ spec:
           - "delete"
           - "instrumentations,opampbridges,opentelemetrycollectors"
           - "-l"
-          - "helm.sh/chart=opentelemetry-kube-stack-0.20.6"
+          - "helm.sh/chart=opentelemetry-kube-stack-0.20.7"

--- a/charts/opentelemetry-kube-stack/examples/prometheus-otel/rendered/collector.yaml
+++ b/charts/opentelemetry-kube-stack/examples/prometheus-otel/rendered/collector.yaml
@@ -6,7 +6,7 @@ metadata:
   name: example-daemon
   namespace: default
   labels:
-    helm.sh/chart: opentelemetry-kube-stack-0.20.6
+    helm.sh/chart: opentelemetry-kube-stack-0.20.7
     app.kubernetes.io/version: "0.154.0"
     app.kubernetes.io/managed-by: Helm
     release: "example"    

--- a/charts/opentelemetry-kube-stack/examples/prometheus-otel/rendered/exporters/kube-api-server/servicemonitor.yaml
+++ b/charts/opentelemetry-kube-stack/examples/prometheus-otel/rendered/exporters/kube-api-server/servicemonitor.yaml
@@ -7,7 +7,7 @@ metadata:
   namespace: default
   labels:
     app: opentelemetry-kube-stack-apiserver
-    helm.sh/chart: opentelemetry-kube-stack-0.20.6
+    helm.sh/chart: opentelemetry-kube-stack-0.20.7
     app.kubernetes.io/version: "0.154.0"
     app.kubernetes.io/managed-by: Helm
     release: "example"

--- a/charts/opentelemetry-kube-stack/examples/prometheus-otel/rendered/exporters/kube-controller-manager/service.yaml
+++ b/charts/opentelemetry-kube-stack/examples/prometheus-otel/rendered/exporters/kube-controller-manager/service.yaml
@@ -7,7 +7,7 @@ metadata:
   labels:
     app: opentelemetry-kube-stack-kube-controller-manager
     jobLabel: kube-controller-manager
-    helm.sh/chart: opentelemetry-kube-stack-0.20.6
+    helm.sh/chart: opentelemetry-kube-stack-0.20.7
     app.kubernetes.io/version: "0.154.0"
     app.kubernetes.io/managed-by: Helm
     release: "example"

--- a/charts/opentelemetry-kube-stack/examples/prometheus-otel/rendered/exporters/kube-controller-manager/servicemonitor.yaml
+++ b/charts/opentelemetry-kube-stack/examples/prometheus-otel/rendered/exporters/kube-controller-manager/servicemonitor.yaml
@@ -7,7 +7,7 @@ metadata:
   namespace: default
   labels:
     app: opentelemetry-kube-stack-kube-controller-manager
-    helm.sh/chart: opentelemetry-kube-stack-0.20.6
+    helm.sh/chart: opentelemetry-kube-stack-0.20.7
     app.kubernetes.io/version: "0.154.0"
     app.kubernetes.io/managed-by: Helm
     release: "example"

--- a/charts/opentelemetry-kube-stack/examples/prometheus-otel/rendered/exporters/kube-dns/service.yaml
+++ b/charts/opentelemetry-kube-stack/examples/prometheus-otel/rendered/exporters/kube-dns/service.yaml
@@ -7,7 +7,7 @@ metadata:
   labels:
     app: opentelemetry-kube-stack-kube-dns
     jobLabel: kube-dns
-    helm.sh/chart: opentelemetry-kube-stack-0.20.6
+    helm.sh/chart: opentelemetry-kube-stack-0.20.7
     app.kubernetes.io/version: "0.154.0"
     app.kubernetes.io/managed-by: Helm
     release: "example"

--- a/charts/opentelemetry-kube-stack/examples/prometheus-otel/rendered/exporters/kube-dns/servicemonitor.yaml
+++ b/charts/opentelemetry-kube-stack/examples/prometheus-otel/rendered/exporters/kube-dns/servicemonitor.yaml
@@ -7,7 +7,7 @@ metadata:
   namespace: default
   labels:
     app: opentelemetry-kube-stack-kube-dns
-    helm.sh/chart: opentelemetry-kube-stack-0.20.6
+    helm.sh/chart: opentelemetry-kube-stack-0.20.7
     app.kubernetes.io/version: "0.154.0"
     app.kubernetes.io/managed-by: Helm
     release: "example"

--- a/charts/opentelemetry-kube-stack/examples/prometheus-otel/rendered/exporters/kube-etcd/service.yaml
+++ b/charts/opentelemetry-kube-stack/examples/prometheus-otel/rendered/exporters/kube-etcd/service.yaml
@@ -7,7 +7,7 @@ metadata:
   labels:
     app: opentelemetry-kube-stack-kube-etcd
     jobLabel: kube-etcd
-    helm.sh/chart: opentelemetry-kube-stack-0.20.6
+    helm.sh/chart: opentelemetry-kube-stack-0.20.7
     app.kubernetes.io/version: "0.154.0"
     app.kubernetes.io/managed-by: Helm
     release: "example"

--- a/charts/opentelemetry-kube-stack/examples/prometheus-otel/rendered/exporters/kube-etcd/servicemonitor.yaml
+++ b/charts/opentelemetry-kube-stack/examples/prometheus-otel/rendered/exporters/kube-etcd/servicemonitor.yaml
@@ -7,7 +7,7 @@ metadata:
   namespace: default
   labels:
     app: opentelemetry-kube-stack-kube-etcd
-    helm.sh/chart: opentelemetry-kube-stack-0.20.6
+    helm.sh/chart: opentelemetry-kube-stack-0.20.7
     app.kubernetes.io/version: "0.154.0"
     app.kubernetes.io/managed-by: Helm
     release: "example"

--- a/charts/opentelemetry-kube-stack/examples/prometheus-otel/rendered/exporters/kube-proxy/service.yaml
+++ b/charts/opentelemetry-kube-stack/examples/prometheus-otel/rendered/exporters/kube-proxy/service.yaml
@@ -7,7 +7,7 @@ metadata:
   labels:
     app: opentelemetry-kube-stack-kube-proxy
     jobLabel: kube-proxy
-    helm.sh/chart: opentelemetry-kube-stack-0.20.6
+    helm.sh/chart: opentelemetry-kube-stack-0.20.7
     app.kubernetes.io/version: "0.154.0"
     app.kubernetes.io/managed-by: Helm
     release: "example"

--- a/charts/opentelemetry-kube-stack/examples/prometheus-otel/rendered/exporters/kube-proxy/servicemonitor.yaml
+++ b/charts/opentelemetry-kube-stack/examples/prometheus-otel/rendered/exporters/kube-proxy/servicemonitor.yaml
@@ -7,7 +7,7 @@ metadata:
   namespace: default
   labels:
     app: opentelemetry-kube-stack-kube-proxy
-    helm.sh/chart: opentelemetry-kube-stack-0.20.6
+    helm.sh/chart: opentelemetry-kube-stack-0.20.7
     app.kubernetes.io/version: "0.154.0"
     app.kubernetes.io/managed-by: Helm
     release: "example"

--- a/charts/opentelemetry-kube-stack/examples/prometheus-otel/rendered/exporters/kube-scheduler/service.yaml
+++ b/charts/opentelemetry-kube-stack/examples/prometheus-otel/rendered/exporters/kube-scheduler/service.yaml
@@ -7,7 +7,7 @@ metadata:
   labels:
     app: opentelemetry-kube-stack-kube-scheduler
     jobLabel: kube-scheduler
-    helm.sh/chart: opentelemetry-kube-stack-0.20.6
+    helm.sh/chart: opentelemetry-kube-stack-0.20.7
     app.kubernetes.io/version: "0.154.0"
     app.kubernetes.io/managed-by: Helm
     release: "example"

--- a/charts/opentelemetry-kube-stack/examples/prometheus-otel/rendered/exporters/kube-scheduler/servicemonitor.yaml
+++ b/charts/opentelemetry-kube-stack/examples/prometheus-otel/rendered/exporters/kube-scheduler/servicemonitor.yaml
@@ -7,7 +7,7 @@ metadata:
   namespace: default
   labels:
     app: opentelemetry-kube-stack-kube-scheduler
-    helm.sh/chart: opentelemetry-kube-stack-0.20.6
+    helm.sh/chart: opentelemetry-kube-stack-0.20.7
     app.kubernetes.io/version: "0.154.0"
     app.kubernetes.io/managed-by: Helm
     release: "example"

--- a/charts/opentelemetry-kube-stack/examples/prometheus-otel/rendered/hooks.yaml
+++ b/charts/opentelemetry-kube-stack/examples/prometheus-otel/rendered/hooks.yaml
@@ -61,4 +61,4 @@ spec:
           - "delete"
           - "instrumentations,opampbridges,opentelemetrycollectors"
           - "-l"
-          - "helm.sh/chart=opentelemetry-kube-stack-0.20.6"
+          - "helm.sh/chart=opentelemetry-kube-stack-0.20.7"

--- a/charts/opentelemetry-kube-stack/examples/secrets-csi-driver/rendered/collector.yaml
+++ b/charts/opentelemetry-kube-stack/examples/secrets-csi-driver/rendered/collector.yaml
@@ -6,7 +6,7 @@ metadata:
   name: example-daemon
   namespace: default
   labels:
-    helm.sh/chart: opentelemetry-kube-stack-0.20.6
+    helm.sh/chart: opentelemetry-kube-stack-0.20.7
     app.kubernetes.io/version: "0.154.0"
     app.kubernetes.io/managed-by: Helm
     release: "example"        

--- a/charts/opentelemetry-kube-stack/examples/secrets-csi-driver/rendered/hooks.yaml
+++ b/charts/opentelemetry-kube-stack/examples/secrets-csi-driver/rendered/hooks.yaml
@@ -61,4 +61,4 @@ spec:
           - "delete"
           - "instrumentations,opampbridges,opentelemetrycollectors"
           - "-l"
-          - "helm.sh/chart=opentelemetry-kube-stack-0.20.6"
+          - "helm.sh/chart=opentelemetry-kube-stack-0.20.7"

--- a/charts/opentelemetry-kube-stack/templates/_config.tpl
+++ b/charts/opentelemetry-kube-stack/templates/_config.tpl
@@ -129,6 +129,11 @@ target allocator has a receiver to populate.
 {{- $config = (include "opentelemetry-kube-stack.collector.applyResourceDetectionConfig" (dict "collector" $collector) | fromYaml) -}}
 {{- $_ := set $collector "config" $config }}
 {{- end }}
+{{- $effectiveResourceAttributes := mustMergeOverwrite (deepCopy (.resourceAttributes | default dict)) ($collector.resourceAttributes | default dict) }}
+{{- if $effectiveResourceAttributes }}
+{{- $config = (include "opentelemetry-kube-stack.collector.applyResourceAttributesConfig" (dict "collector" $collector "resourceAttributes" $effectiveResourceAttributes) | fromYaml) -}}
+{{- $_ := set $collector "config" $config }}
+{{- end }}
 {{- tpl (toYaml $collector.config) . | nindent 4 }}
 {{- end }}
 
@@ -710,6 +715,24 @@ receivers:
 
 {{- $_ := set $processors $processorName $resourceDetectionProcessor }}
 {{- $_ := set $config "processors" $processors }}
+{{- $config | toYaml }}
+{{- end }}
+
+{{/* Renders `resourceAttributes` as a `resource/global` upsert processor appended to every pipeline. */}}
+{{- define "opentelemetry-kube-stack.collector.applyResourceAttributesConfig" -}}
+{{- $processorName := "resource/global" }}
+{{- $attributes := list }}
+{{- range $key, $value := .resourceAttributes }}
+{{- $attributes = append $attributes (dict "key" $key "value" $value "action" "upsert") }}
+{{- end }}
+{{- $override := dict "processors" (dict $processorName (dict "attributes" $attributes)) }}
+{{- $config := mustMergeOverwrite $override .collector.config }}
+{{- $pipelines := dig "service" "pipelines" dict $config }}
+{{- range $signal, $pipeline := $pipelines }}
+{{- if and $pipeline (not (has $processorName (get $pipeline "processors" | default list))) }}
+{{- $_ := set $pipeline "processors" (append (get $pipeline "processors" | default list) $processorName) }}
+{{- end }}
+{{- end }}
 {{- $config | toYaml }}
 {{- end }}
 

--- a/charts/opentelemetry-kube-stack/templates/collector.yaml
+++ b/charts/opentelemetry-kube-stack/templates/collector.yaml
@@ -3,7 +3,7 @@
 {{- if $.Values.defaultCRConfig.enabled }}
 {{- $collector = (mergeOverwrite (deepCopy $.Values.defaultCRConfig) $collector) }}
 {{- end }}
-{{- $merged := (dict "Template" $.Template "Files" $.Files "Chart" $.Chart "clusterRole" $.Values.clusterRole "collector" $collector "Release" $.Release "fullnameOverride" $.Values.fullnameOverride "presets" $.Values.presets "namespace" (include "opentelemetry-kube-stack.namespace" $)  "kubelet" $.Values.kubelet "clusterName" $.Values.clusterName "rewriteDeprecatedComponentNames" $.Values.rewriteDeprecatedComponentNames) }}
+{{- $merged := (dict "Template" $.Template "Files" $.Files "Chart" $.Chart "clusterRole" $.Values.clusterRole "collector" $collector "Release" $.Release "fullnameOverride" $.Values.fullnameOverride "presets" $.Values.presets "namespace" (include "opentelemetry-kube-stack.namespace" $)  "kubelet" $.Values.kubelet "clusterName" $.Values.clusterName "rewriteDeprecatedComponentNames" $.Values.rewriteDeprecatedComponentNames "resourceAttributes" ($.Values.resourceAttributes | default dict)) }}
 {{- $fullname := (include "opentelemetry-kube-stack.collectorFullname" $merged) }}
 ---
 apiVersion: opentelemetry.io/v1beta1

--- a/charts/opentelemetry-kube-stack/templates/instrumentation.yaml
+++ b/charts/opentelemetry-kube-stack/templates/instrumentation.yaml
@@ -25,7 +25,12 @@ spec:
   env:
     {{- $envOutput | nindent 4 }}
   {{- end }}
-  {{- with .Values.instrumentation.resource }}
+  {{- $resource := deepCopy (.Values.instrumentation.resource | default dict) }}
+  {{- if .Values.resourceAttributes }}
+  {{- $merged := mustMergeOverwrite (deepCopy .Values.resourceAttributes) ($resource.resourceAttributes | default dict) }}
+  {{- $_ := set $resource "resourceAttributes" $merged }}
+  {{- end }}
+  {{- with $resource }}
   resource:
     {{- toYaml . | nindent 4 }}
   {{- end }}

--- a/charts/opentelemetry-kube-stack/values.schema.json
+++ b/charts/opentelemetry-kube-stack/values.schema.json
@@ -1734,6 +1734,17 @@
           "type": "string",
           "default": ""
         },
+        "resourceAttributes": {
+          "description": "Per-collector resource attributes. Merged over the top-level `resourceAttributes` map (per-collector keys win on conflict) and rendered as a `resource/global` processor appended to every pipeline.",
+          "type": "object",
+          "additionalProperties": {
+            "type": [
+              "string",
+              "number",
+              "boolean"
+            ]
+          }
+        },
         "resources": {
           "$ref": "#/$defs/ResourceRequirements"
         },
@@ -4517,6 +4528,17 @@
     },
     "clusterName": {
       "type": "string"
+    },
+    "resourceAttributes": {
+      "description": "Default resource attributes merged into every collector pipeline (as a `resource/global` processor with `upsert` action) and into the Instrumentation CR's `resource.resourceAttributes`.",
+      "type": "object",
+      "additionalProperties": {
+        "type": [
+          "string",
+          "number",
+          "boolean"
+        ]
+      }
     },
     "rewriteDeprecatedComponentNames": {
       "description": "When true, deprecated Collector component names are rewritten to their current lower_snake_case names in user-provided and preset-generated configuration.",

--- a/charts/opentelemetry-kube-stack/values.yaml
+++ b/charts/opentelemetry-kube-stack/values.yaml
@@ -8,6 +8,14 @@ namespaceOverride: ""
 # better integration.
 clusterName: "unknown_k8s_cluster"
 
+# Default resource attributes applied to every collector pipeline (as a
+# `resource/global` upsert processor) and merged into the Instrumentation CR's
+# `resource.resourceAttributes`. Override per collector via
+# `collectors.<name>.resourceAttributes`.
+resourceAttributes: {}
+#   deployment.environment.name: production
+#   k8s.cluster.name: unknown_k8s_cluster
+
 # Rewrite deprecated component names (e.g. k8sattributes -> k8s_attributes
 # processor, hostmetrics -> host_metrics receiver) in the generated config.
 # Set to false if using older Collector images that do not recognize the new


### PR DESCRIPTION
#### Description

Adds a top-level `resourceAttributes: {}` map to the `opentelemetry-kube-stack`
chart, providing a single place to set default resource attributes (e.g.
`deployment.environment.name`, `k8s.cluster.name`) that apply to both the collectors this
chart deploys and the `Instrumentation` CR it manages. Previously, users had
to duplicate the same attributes in two unrelated places: manually as a
`resource` processor in each collector's config, and again in
`instrumentation.resource.resourceAttributes`.

Wiring:

- **Collectors:** the map is rendered as a `resource/global` processor with
  `action: upsert` and appended to every existing pipeline (traces, metrics,
  logs). `upsert` semantics ensure explicit values here take precedence over
  anything auto-detected earlier in the pipeline (e.g. by
  `resourcedetection`).
- **Instrumentation CR:** the map is merged as defaults into
  `instrumentation.resource.resourceAttributes`; any per-key value already set
  in the instrumentation section wins on conflict, preserving existing
  behavior for users who already configure it there.
- **Per-collector override:** `collectors.<name>.resourceAttributes` is also
  accepted and overlays the top-level map (per-collector keys win) so a
  specific collector pool can extend or override the defaults.


#### Link to tracking issue
Fixes #2338

#### Authorship

- [x] I, a human, wrote this pull request description myself.
