### PR TITLE
[opentelemetry-kube-stack] new inheritDefaultCRConfig option

### DIFF
--- a/charts/opentelemetry-kube-stack/Chart.yaml
+++ b/charts/opentelemetry-kube-stack/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 name: opentelemetry-kube-stack
-version: 0.20.6
+version: 0.20.7
 description: |
   OpenTelemetry Quickstart chart for Kubernetes.
   Installs an operator and collector for an easy way to get started with Kubernetes observability.

--- a/charts/opentelemetry-kube-stack/examples/cloud-demo/rendered/bridge.yaml
+++ b/charts/opentelemetry-kube-stack/examples/cloud-demo/rendered/bridge.yaml
@@ -5,7 +5,7 @@ kind: OpAMPBridge
 metadata:
   name: example
   labels:
-    helm.sh/chart: opentelemetry-kube-stack-0.20.6
+    helm.sh/chart: opentelemetry-kube-stack-0.20.7
     app.kubernetes.io/version: "0.154.0"
     app.kubernetes.io/managed-by: Helm
     release: "example"    

--- a/charts/opentelemetry-kube-stack/examples/cloud-demo/rendered/collector.yaml
+++ b/charts/opentelemetry-kube-stack/examples/cloud-demo/rendered/collector.yaml
@@ -6,7 +6,7 @@ metadata:
   name: example-daemon
   namespace: default
   labels:
-    helm.sh/chart: opentelemetry-kube-stack-0.20.6
+    helm.sh/chart: opentelemetry-kube-stack-0.20.7
     app.kubernetes.io/version: "0.154.0"
     app.kubernetes.io/managed-by: Helm
     release: "example"        

--- a/charts/opentelemetry-kube-stack/examples/cloud-demo/rendered/hooks.yaml
+++ b/charts/opentelemetry-kube-stack/examples/cloud-demo/rendered/hooks.yaml
@@ -61,4 +61,4 @@ spec:
           - "delete"
           - "instrumentations,opampbridges,opentelemetrycollectors"
           - "-l"
-          - "helm.sh/chart=opentelemetry-kube-stack-0.20.6"
+          - "helm.sh/chart=opentelemetry-kube-stack-0.20.7"

--- a/charts/opentelemetry-kube-stack/examples/cloud-demo/rendered/instrumentation.yaml
+++ b/charts/opentelemetry-kube-stack/examples/cloud-demo/rendered/instrumentation.yaml
@@ -5,7 +5,7 @@ kind: Instrumentation
 metadata:
   name: example
   labels:
-    helm.sh/chart: opentelemetry-kube-stack-0.20.6
+    helm.sh/chart: opentelemetry-kube-stack-0.20.7
     app.kubernetes.io/version: "0.154.0"
     app.kubernetes.io/managed-by: Helm
     release: "example"    

--- a/charts/opentelemetry-kube-stack/examples/daemonset-annotation-discovery-logs/rendered/collector.yaml
+++ b/charts/opentelemetry-kube-stack/examples/daemonset-annotation-discovery-logs/rendered/collector.yaml
@@ -6,7 +6,7 @@ metadata:
   name: example-daemon
   namespace: default
   labels:
-    helm.sh/chart: opentelemetry-kube-stack-0.20.6
+    helm.sh/chart: opentelemetry-kube-stack-0.20.7
     app.kubernetes.io/version: "0.154.0"
     app.kubernetes.io/managed-by: Helm
     release: "example"        

--- a/charts/opentelemetry-kube-stack/examples/daemonset-annotation-discovery-logs/rendered/hooks.yaml
+++ b/charts/opentelemetry-kube-stack/examples/daemonset-annotation-discovery-logs/rendered/hooks.yaml
@@ -61,4 +61,4 @@ spec:
           - "delete"
           - "instrumentations,opampbridges,opentelemetrycollectors"
           - "-l"
-          - "helm.sh/chart=opentelemetry-kube-stack-0.20.6"
+          - "helm.sh/chart=opentelemetry-kube-stack-0.20.7"

--- a/charts/opentelemetry-kube-stack/examples/daemonset-annotation-discovery-metrics/rendered/collector.yaml
+++ b/charts/opentelemetry-kube-stack/examples/daemonset-annotation-discovery-metrics/rendered/collector.yaml
@@ -6,7 +6,7 @@ metadata:
   name: example-daemon
   namespace: default
   labels:
-    helm.sh/chart: opentelemetry-kube-stack-0.20.6
+    helm.sh/chart: opentelemetry-kube-stack-0.20.7
     app.kubernetes.io/version: "0.154.0"
     app.kubernetes.io/managed-by: Helm
     release: "example"        

--- a/charts/opentelemetry-kube-stack/examples/daemonset-annotation-discovery-metrics/rendered/hooks.yaml
+++ b/charts/opentelemetry-kube-stack/examples/daemonset-annotation-discovery-metrics/rendered/hooks.yaml
@@ -61,4 +61,4 @@ spec:
           - "delete"
           - "instrumentations,opampbridges,opentelemetrycollectors"
           - "-l"
-          - "helm.sh/chart=opentelemetry-kube-stack-0.20.6"
+          - "helm.sh/chart=opentelemetry-kube-stack-0.20.7"

--- a/charts/opentelemetry-kube-stack/examples/daemonset-annotation-discovery/rendered/collector.yaml
+++ b/charts/opentelemetry-kube-stack/examples/daemonset-annotation-discovery/rendered/collector.yaml
@@ -6,7 +6,7 @@ metadata:
   name: example-daemon
   namespace: default
   labels:
-    helm.sh/chart: opentelemetry-kube-stack-0.20.6
+    helm.sh/chart: opentelemetry-kube-stack-0.20.7
     app.kubernetes.io/version: "0.154.0"
     app.kubernetes.io/managed-by: Helm
     release: "example"        

--- a/charts/opentelemetry-kube-stack/examples/daemonset-annotation-discovery/rendered/hooks.yaml
+++ b/charts/opentelemetry-kube-stack/examples/daemonset-annotation-discovery/rendered/hooks.yaml
@@ -61,4 +61,4 @@ spec:
           - "delete"
           - "instrumentations,opampbridges,opentelemetrycollectors"
           - "-l"
-          - "helm.sh/chart=opentelemetry-kube-stack-0.20.6"
+          - "helm.sh/chart=opentelemetry-kube-stack-0.20.7"

--- a/charts/opentelemetry-kube-stack/examples/daemonset-kubernetes-objects/rendered/collector.yaml
+++ b/charts/opentelemetry-kube-stack/examples/daemonset-kubernetes-objects/rendered/collector.yaml
@@ -6,7 +6,7 @@ metadata:
   name: example-daemon
   namespace: default
   labels:
-    helm.sh/chart: opentelemetry-kube-stack-0.20.6
+    helm.sh/chart: opentelemetry-kube-stack-0.20.7
     app.kubernetes.io/version: "0.154.0"
     app.kubernetes.io/managed-by: Helm
     release: "example"        

--- a/charts/opentelemetry-kube-stack/examples/daemonset-kubernetes-objects/rendered/hooks.yaml
+++ b/charts/opentelemetry-kube-stack/examples/daemonset-kubernetes-objects/rendered/hooks.yaml
@@ -61,4 +61,4 @@ spec:
           - "delete"
           - "instrumentations,opampbridges,opentelemetrycollectors"
           - "-l"
-          - "helm.sh/chart=opentelemetry-kube-stack-0.20.6"
+          - "helm.sh/chart=opentelemetry-kube-stack-0.20.7"

--- a/charts/opentelemetry-kube-stack/examples/daemonset-prometheus-presets/rendered/collector.yaml
+++ b/charts/opentelemetry-kube-stack/examples/daemonset-prometheus-presets/rendered/collector.yaml
@@ -6,7 +6,7 @@ metadata:
   name: example-daemon
   namespace: default
   labels:
-    helm.sh/chart: opentelemetry-kube-stack-0.20.6
+    helm.sh/chart: opentelemetry-kube-stack-0.20.7
     app.kubernetes.io/version: "0.154.0"
     app.kubernetes.io/managed-by: Helm
     release: "example"        

--- a/charts/opentelemetry-kube-stack/examples/daemonset-prometheus-presets/rendered/hooks.yaml
+++ b/charts/opentelemetry-kube-stack/examples/daemonset-prometheus-presets/rendered/hooks.yaml
@@ -61,4 +61,4 @@ spec:
           - "delete"
           - "instrumentations,opampbridges,opentelemetrycollectors"
           - "-l"
-          - "helm.sh/chart=opentelemetry-kube-stack-0.20.6"
+          - "helm.sh/chart=opentelemetry-kube-stack-0.20.7"

--- a/charts/opentelemetry-kube-stack/examples/default/rendered/collector.yaml
+++ b/charts/opentelemetry-kube-stack/examples/default/rendered/collector.yaml
@@ -6,7 +6,7 @@ metadata:
   name: example-daemon
   namespace: default
   labels:
-    helm.sh/chart: opentelemetry-kube-stack-0.20.6
+    helm.sh/chart: opentelemetry-kube-stack-0.20.7
     app.kubernetes.io/version: "0.154.0"
     app.kubernetes.io/managed-by: Helm
     release: "example"        

--- a/charts/opentelemetry-kube-stack/examples/default/rendered/hooks.yaml
+++ b/charts/opentelemetry-kube-stack/examples/default/rendered/hooks.yaml
@@ -61,4 +61,4 @@ spec:
           - "delete"
           - "instrumentations,opampbridges,opentelemetrycollectors"
           - "-l"
-          - "helm.sh/chart=opentelemetry-kube-stack-0.20.6"
+          - "helm.sh/chart=opentelemetry-kube-stack-0.20.7"

--- a/charts/opentelemetry-kube-stack/examples/isolated-multicollector-deployment/rendered/collector.yaml
+++ b/charts/opentelemetry-kube-stack/examples/isolated-multicollector-deployment/rendered/collector.yaml
@@ -6,7 +6,7 @@ metadata:
   name: agent
   namespace: default
   labels:
-    helm.sh/chart: opentelemetry-kube-stack-0.20.6
+    helm.sh/chart: opentelemetry-kube-stack-0.20.7
     app.kubernetes.io/version: "0.154.0"
     app.kubernetes.io/managed-by: Helm
     release: "example"        
@@ -232,7 +232,7 @@ metadata:
   name: gateway
   namespace: default
   labels:
-    helm.sh/chart: opentelemetry-kube-stack-0.20.6
+    helm.sh/chart: opentelemetry-kube-stack-0.20.7
     app.kubernetes.io/version: "0.154.0"
     app.kubernetes.io/managed-by: Helm
     release: "example"        
@@ -365,7 +365,7 @@ metadata:
   name: ingress
   namespace: default
   labels:
-    helm.sh/chart: opentelemetry-kube-stack-0.20.6
+    helm.sh/chart: opentelemetry-kube-stack-0.20.7
     app.kubernetes.io/version: "0.154.0"
     app.kubernetes.io/managed-by: Helm
     release: "example"        

--- a/charts/opentelemetry-kube-stack/examples/isolated-multicollector-deployment/rendered/hooks.yaml
+++ b/charts/opentelemetry-kube-stack/examples/isolated-multicollector-deployment/rendered/hooks.yaml
@@ -61,4 +61,4 @@ spec:
           - "delete"
           - "instrumentations,opampbridges,opentelemetrycollectors"
           - "-l"
-          - "helm.sh/chart=opentelemetry-kube-stack-0.20.6"
+          - "helm.sh/chart=opentelemetry-kube-stack-0.20.7"

--- a/charts/opentelemetry-kube-stack/examples/no-leader-election-extension/rendered/collector.yaml
+++ b/charts/opentelemetry-kube-stack/examples/no-leader-election-extension/rendered/collector.yaml
@@ -6,7 +6,7 @@ metadata:
   name: example-cluster-stats
   namespace: default
   labels:
-    helm.sh/chart: opentelemetry-kube-stack-0.20.6
+    helm.sh/chart: opentelemetry-kube-stack-0.20.7
     app.kubernetes.io/version: "0.154.0"
     app.kubernetes.io/managed-by: Helm
     release: "example"        
@@ -173,7 +173,7 @@ metadata:
   name: example-daemon
   namespace: default
   labels:
-    helm.sh/chart: opentelemetry-kube-stack-0.20.6
+    helm.sh/chart: opentelemetry-kube-stack-0.20.7
     app.kubernetes.io/version: "0.154.0"
     app.kubernetes.io/managed-by: Helm
     release: "example"        

--- a/charts/opentelemetry-kube-stack/examples/no-leader-election-extension/rendered/hooks.yaml
+++ b/charts/opentelemetry-kube-stack/examples/no-leader-election-extension/rendered/hooks.yaml
@@ -61,4 +61,4 @@ spec:
           - "delete"
           - "instrumentations,opampbridges,opentelemetrycollectors"
           - "-l"
-          - "helm.sh/chart=opentelemetry-kube-stack-0.20.6"
+          - "helm.sh/chart=opentelemetry-kube-stack-0.20.7"

--- a/charts/opentelemetry-kube-stack/examples/prometheus-otel/rendered/collector.yaml
+++ b/charts/opentelemetry-kube-stack/examples/prometheus-otel/rendered/collector.yaml
@@ -6,7 +6,7 @@ metadata:
   name: example-daemon
   namespace: default
   labels:
-    helm.sh/chart: opentelemetry-kube-stack-0.20.6
+    helm.sh/chart: opentelemetry-kube-stack-0.20.7
     app.kubernetes.io/version: "0.154.0"
     app.kubernetes.io/managed-by: Helm
     release: "example"    

--- a/charts/opentelemetry-kube-stack/examples/prometheus-otel/rendered/exporters/kube-api-server/servicemonitor.yaml
+++ b/charts/opentelemetry-kube-stack/examples/prometheus-otel/rendered/exporters/kube-api-server/servicemonitor.yaml
@@ -7,7 +7,7 @@ metadata:
   namespace: default
   labels:
     app: opentelemetry-kube-stack-apiserver
-    helm.sh/chart: opentelemetry-kube-stack-0.20.6
+    helm.sh/chart: opentelemetry-kube-stack-0.20.7
     app.kubernetes.io/version: "0.154.0"
     app.kubernetes.io/managed-by: Helm
     release: "example"

--- a/charts/opentelemetry-kube-stack/examples/prometheus-otel/rendered/exporters/kube-controller-manager/service.yaml
+++ b/charts/opentelemetry-kube-stack/examples/prometheus-otel/rendered/exporters/kube-controller-manager/service.yaml
@@ -7,7 +7,7 @@ metadata:
   labels:
     app: opentelemetry-kube-stack-kube-controller-manager
     jobLabel: kube-controller-manager
-    helm.sh/chart: opentelemetry-kube-stack-0.20.6
+    helm.sh/chart: opentelemetry-kube-stack-0.20.7
     app.kubernetes.io/version: "0.154.0"
     app.kubernetes.io/managed-by: Helm
     release: "example"

--- a/charts/opentelemetry-kube-stack/examples/prometheus-otel/rendered/exporters/kube-controller-manager/servicemonitor.yaml
+++ b/charts/opentelemetry-kube-stack/examples/prometheus-otel/rendered/exporters/kube-controller-manager/servicemonitor.yaml
@@ -7,7 +7,7 @@ metadata:
   namespace: default
   labels:
     app: opentelemetry-kube-stack-kube-controller-manager
-    helm.sh/chart: opentelemetry-kube-stack-0.20.6
+    helm.sh/chart: opentelemetry-kube-stack-0.20.7
     app.kubernetes.io/version: "0.154.0"
     app.kubernetes.io/managed-by: Helm
     release: "example"

--- a/charts/opentelemetry-kube-stack/examples/prometheus-otel/rendered/exporters/kube-dns/service.yaml
+++ b/charts/opentelemetry-kube-stack/examples/prometheus-otel/rendered/exporters/kube-dns/service.yaml
@@ -7,7 +7,7 @@ metadata:
   labels:
     app: opentelemetry-kube-stack-kube-dns
     jobLabel: kube-dns
-    helm.sh/chart: opentelemetry-kube-stack-0.20.6
+    helm.sh/chart: opentelemetry-kube-stack-0.20.7
     app.kubernetes.io/version: "0.154.0"
     app.kubernetes.io/managed-by: Helm
     release: "example"

--- a/charts/opentelemetry-kube-stack/examples/prometheus-otel/rendered/exporters/kube-dns/servicemonitor.yaml
+++ b/charts/opentelemetry-kube-stack/examples/prometheus-otel/rendered/exporters/kube-dns/servicemonitor.yaml
@@ -7,7 +7,7 @@ metadata:
   namespace: default
   labels:
     app: opentelemetry-kube-stack-kube-dns
-    helm.sh/chart: opentelemetry-kube-stack-0.20.6
+    helm.sh/chart: opentelemetry-kube-stack-0.20.7
     app.kubernetes.io/version: "0.154.0"
     app.kubernetes.io/managed-by: Helm
     release: "example"

--- a/charts/opentelemetry-kube-stack/examples/prometheus-otel/rendered/exporters/kube-etcd/service.yaml
+++ b/charts/opentelemetry-kube-stack/examples/prometheus-otel/rendered/exporters/kube-etcd/service.yaml
@@ -7,7 +7,7 @@ metadata:
   labels:
     app: opentelemetry-kube-stack-kube-etcd
     jobLabel: kube-etcd
-    helm.sh/chart: opentelemetry-kube-stack-0.20.6
+    helm.sh/chart: opentelemetry-kube-stack-0.20.7
     app.kubernetes.io/version: "0.154.0"
     app.kubernetes.io/managed-by: Helm
     release: "example"

--- a/charts/opentelemetry-kube-stack/examples/prometheus-otel/rendered/exporters/kube-etcd/servicemonitor.yaml
+++ b/charts/opentelemetry-kube-stack/examples/prometheus-otel/rendered/exporters/kube-etcd/servicemonitor.yaml
@@ -7,7 +7,7 @@ metadata:
   namespace: default
   labels:
     app: opentelemetry-kube-stack-kube-etcd
-    helm.sh/chart: opentelemetry-kube-stack-0.20.6
+    helm.sh/chart: opentelemetry-kube-stack-0.20.7
     app.kubernetes.io/version: "0.154.0"
     app.kubernetes.io/managed-by: Helm
     release: "example"

--- a/charts/opentelemetry-kube-stack/examples/prometheus-otel/rendered/exporters/kube-proxy/service.yaml
+++ b/charts/opentelemetry-kube-stack/examples/prometheus-otel/rendered/exporters/kube-proxy/service.yaml
@@ -7,7 +7,7 @@ metadata:
   labels:
     app: opentelemetry-kube-stack-kube-proxy
     jobLabel: kube-proxy
-    helm.sh/chart: opentelemetry-kube-stack-0.20.6
+    helm.sh/chart: opentelemetry-kube-stack-0.20.7
     app.kubernetes.io/version: "0.154.0"
     app.kubernetes.io/managed-by: Helm
     release: "example"

--- a/charts/opentelemetry-kube-stack/examples/prometheus-otel/rendered/exporters/kube-proxy/servicemonitor.yaml
+++ b/charts/opentelemetry-kube-stack/examples/prometheus-otel/rendered/exporters/kube-proxy/servicemonitor.yaml
@@ -7,7 +7,7 @@ metadata:
   namespace: default
   labels:
     app: opentelemetry-kube-stack-kube-proxy
-    helm.sh/chart: opentelemetry-kube-stack-0.20.6
+    helm.sh/chart: opentelemetry-kube-stack-0.20.7
     app.kubernetes.io/version: "0.154.0"
     app.kubernetes.io/managed-by: Helm
     release: "example"

--- a/charts/opentelemetry-kube-stack/examples/prometheus-otel/rendered/exporters/kube-scheduler/service.yaml
+++ b/charts/opentelemetry-kube-stack/examples/prometheus-otel/rendered/exporters/kube-scheduler/service.yaml
@@ -7,7 +7,7 @@ metadata:
   labels:
     app: opentelemetry-kube-stack-kube-scheduler
     jobLabel: kube-scheduler
-    helm.sh/chart: opentelemetry-kube-stack-0.20.6
+    helm.sh/chart: opentelemetry-kube-stack-0.20.7
     app.kubernetes.io/version: "0.154.0"
     app.kubernetes.io/managed-by: Helm
     release: "example"

--- a/charts/opentelemetry-kube-stack/examples/prometheus-otel/rendered/exporters/kube-scheduler/servicemonitor.yaml
+++ b/charts/opentelemetry-kube-stack/examples/prometheus-otel/rendered/exporters/kube-scheduler/servicemonitor.yaml
@@ -7,7 +7,7 @@ metadata:
   namespace: default
   labels:
     app: opentelemetry-kube-stack-kube-scheduler
-    helm.sh/chart: opentelemetry-kube-stack-0.20.6
+    helm.sh/chart: opentelemetry-kube-stack-0.20.7
     app.kubernetes.io/version: "0.154.0"
     app.kubernetes.io/managed-by: Helm
     release: "example"

--- a/charts/opentelemetry-kube-stack/examples/prometheus-otel/rendered/hooks.yaml
+++ b/charts/opentelemetry-kube-stack/examples/prometheus-otel/rendered/hooks.yaml
@@ -61,4 +61,4 @@ spec:
           - "delete"
           - "instrumentations,opampbridges,opentelemetrycollectors"
           - "-l"
-          - "helm.sh/chart=opentelemetry-kube-stack-0.20.6"
+          - "helm.sh/chart=opentelemetry-kube-stack-0.20.7"

--- a/charts/opentelemetry-kube-stack/examples/secrets-csi-driver/rendered/collector.yaml
+++ b/charts/opentelemetry-kube-stack/examples/secrets-csi-driver/rendered/collector.yaml
@@ -6,7 +6,7 @@ metadata:
   name: example-daemon
   namespace: default
   labels:
-    helm.sh/chart: opentelemetry-kube-stack-0.20.6
+    helm.sh/chart: opentelemetry-kube-stack-0.20.7
     app.kubernetes.io/version: "0.154.0"
     app.kubernetes.io/managed-by: Helm
     release: "example"        

--- a/charts/opentelemetry-kube-stack/examples/secrets-csi-driver/rendered/hooks.yaml
+++ b/charts/opentelemetry-kube-stack/examples/secrets-csi-driver/rendered/hooks.yaml
@@ -61,4 +61,4 @@ spec:
           - "delete"
           - "instrumentations,opampbridges,opentelemetrycollectors"
           - "-l"
-          - "helm.sh/chart=opentelemetry-kube-stack-0.20.6"
+          - "helm.sh/chart=opentelemetry-kube-stack-0.20.7"

--- a/charts/opentelemetry-kube-stack/templates/NOTES.txt
+++ b/charts/opentelemetry-kube-stack/templates/NOTES.txt
@@ -18,13 +18,11 @@ With the features you've enabled, you can:
 * Manually instrument and manually configure applications:
    Bundle the OTel SDK in your application containers and manually configure them using:
 {{- range $_, $collector := $.Values.collectors -}}
-{{- if $.Values.defaultCRConfig.enabled }}
-{{- $collector = (mergeOverwrite (deepCopy $.Values.defaultCRConfig) $collector) }}
-{{- end }}
+{{- $collector = (include "opentelemetry-kube-stack.mergeCollector" (dict "root" $ "collector" $collector) | fromYaml) }}
 {{- $merged := (dict "Template" $.Template "Files" $.Files "Chart" $.Chart "clusterRole" $.Values.clusterRole "collector" $collector "Release" $.Release "fullnameOverride" $.Values.fullnameOverride "presets" $.Values.presets "namespace" (include "opentelemetry-kube-stack.namespace" $)  "kubelet" $.Values.kubelet "clusterName" $.Values.clusterName) }}
 {{- $fullname := (include "opentelemetry-kube-stack.collectorFullname" $merged) }}
 {{- range $_, $protocol := list "grpc" "http" -}}
-{{ $endpoint := dig "receivers" "otlp" "protocols" $protocol "endpoint" "" $collector.config}}
+{{ $endpoint := dig "receivers" "otlp" "protocols" $protocol "endpoint" "" ($collector.config | default dict)}}
 {{- if and $collector.enabled (ne $endpoint "") -}}
 {{- $port := regexFind ":[0-9]+$" $endpoint }}
    - {{ $protocol }}: {{ $fullname }}-collector.{{ include "opentelemetry-kube-stack.namespace" $ }}.svc.cluster.local{{ $port }}
@@ -36,9 +34,7 @@ https://opentelemetry.io/docs/platforms/kubernetes/operator/automatic/#add-annot
 {{ end -}}
 
 {{- range $name, $collector := .Values.collectors }}
-{{- if $.Values.defaultCRConfig.enabled }}
-{{- $collector = (mergeOverwrite (deepCopy $.Values.defaultCRConfig) $collector) }}
-{{- end }}
+{{- $collector = (include "opentelemetry-kube-stack.mergeCollector" (dict "root" $ "collector" $collector) | fromYaml) }}
 {{- if $collector.updateStrategy }}
 
 [WARNING] Collector '{{ $name }}': the 'updateStrategy' value is no longer supported in OpenTelemetryCollector v1beta1.

--- a/charts/opentelemetry-kube-stack/templates/_config.tpl
+++ b/charts/opentelemetry-kube-stack/templates/_config.tpl
@@ -80,52 +80,52 @@ target allocator has a receiver to populate.
 {{- $_ := set $config.service.pipelines.metrics "receivers" (append ($config.service.pipelines.metrics.receivers | default list) "prometheus" | uniq) }}
 {{- end }}
 {{- end }}
-{{- if .collector.presets.logsCollection.enabled }}
+{{- if (dig "presets" "logsCollection" "enabled" false .collector) }}
 {{- $_ := set $collector "exclude" (list (printf "/var/log/pods/%s_%s*_*/otc-container/*.log" .namespace (include "opentelemetry-kube-stack.collectorFullname" .))) }}
 {{- $config = (include "opentelemetry-kube-stack.collector.applyLogsCollectionConfig" (dict "collector" $collector) | fromYaml) -}}
 {{- $_ := set $collector "config" $config }}
 {{- end }}
-{{- if or .collector.presets.annotationDiscovery.logs.enabled .collector.presets.annotationDiscovery.metrics.enabled }}
+{{- if or (dig "presets" "annotationDiscovery" "logs" "enabled" false .collector) (dig "presets" "annotationDiscovery" "metrics" "enabled" false .collector) }}
 {{- $config = (include "opentelemetry-kube-stack.applyAnnotationDiscoveryConfig" (dict "collector" $collector) | fromYaml) }}
 {{- $_ := set $collector "config" $config }}
 {{- end }}
-{{- if .collector.presets.hostMetrics.enabled }}
+{{- if (dig "presets" "hostMetrics" "enabled" false .collector) }}
 {{- $config = (include "opentelemetry-kube-stack.collector.applyHostMetricsConfig" (dict "collector" $collector) | fromYaml) -}}
 {{- $_ := set $collector "config" $config }}
 {{- end }}
-{{- if .collector.presets.kubernetesAttributes.enabled }}
+{{- if (dig "presets" "kubernetesAttributes" "enabled" false .collector) }}
 {{- $config = (include "opentelemetry-kube-stack.collector.applyKubernetesAttributesConfig" (dict "collector" $collector) | fromYaml) -}}
 {{- $_ := set $collector "config" $config }}
 {{- end }}
-{{- if .collector.presets.kubeletMetrics.enabled }}
+{{- if (dig "presets" "kubeletMetrics" "enabled" false .collector) }}
 {{- $config = (include "opentelemetry-kube-stack.collector.applyKubeletMetricsConfig" (dict "collector" $collector) | fromYaml) -}}
 {{- $_ := set $collector "config" $config }}
 {{- end }}
-{{- if .collector.presets.prometheus.nodeExporter.enabled }}
+{{- if (dig "presets" "prometheus" "nodeExporter" "enabled" false .collector) }}
 {{- $config = (include "opentelemetry-kube-stack.collector.applyPrometheusScrapeConfig" (dict "collector" $collector "configTemplate" "opentelemetry-kube-stack.collector.prometheusNodeExporterConfig" "receiverName" "prometheus/node_exporter") | fromYaml) -}}
 {{- $_ := set $collector "config" $config }}
 {{- end }}
-{{- if .collector.presets.prometheus.cadvisor.enabled }}
+{{- if (dig "presets" "prometheus" "cadvisor" "enabled" false .collector) }}
 {{- $config = (include "opentelemetry-kube-stack.collector.applyPrometheusScrapeConfig" (dict "collector" $collector "configTemplate" "opentelemetry-kube-stack.collector.prometheusCadvisorConfig" "receiverName" "prometheus/cadvisor") | fromYaml) -}}
 {{- $_ := set $collector "config" $config }}
 {{- end }}
-{{- if .collector.presets.prometheus.podAnnotations.enabled }}
+{{- if (dig "presets" "prometheus" "podAnnotations" "enabled" false .collector) }}
 {{- $config = (include "opentelemetry-kube-stack.collector.applyPrometheusScrapeConfig" (dict "collector" $collector "configTemplate" "opentelemetry-kube-stack.collector.prometheusPodAnnotationsConfig" "receiverName" "prometheus/pod_annotations") | fromYaml) -}}
 {{- $_ := set $collector "config" $config }}
 {{- end }}
-{{- if .collector.presets.kubernetesEvents.enabled }}
+{{- if (dig "presets" "kubernetesEvents" "enabled" false .collector) }}
 {{- $config = (include "opentelemetry-kube-stack.collector.applyKubernetesEventsConfig" (dict "collector" $collector "namespace" .namespace) | fromYaml) -}}
 {{- $_ := set $collector "config" $config }}
 {{- end }}
-{{- if .collector.presets.kubernetesObjects.enabled }}
+{{- if (dig "presets" "kubernetesObjects" "enabled" false .collector) }}
 {{- $config = (include "opentelemetry-kube-stack.collector.applyKubernetesObjectsConfig" (dict "collector" $collector "namespace" .namespace) | fromYaml) -}}
 {{- $_ := set $collector "config" $config }}
 {{- end }}
-{{- if .collector.presets.clusterMetrics.enabled }}
+{{- if (dig "presets" "clusterMetrics" "enabled" false .collector) }}
 {{- $config = (include "opentelemetry-kube-stack.collector.applyClusterMetricsConfig" (dict "collector" $collector "namespace" .namespace) | fromYaml) -}}
 {{- $_ := set $collector "config" $config }}
 {{- end }}
-{{- if or .collector.presets.resourceDetection.env.enabled .collector.presets.resourceDetection.eks.enabled .collector.presets.resourceDetection.aks.enabled .collector.presets.resourceDetection.gcp.enabled .collector.presets.resourceDetection.k8s_api.enabled }}
+{{- if or (dig "presets" "resourceDetection" "env" "enabled" false .collector) (dig "presets" "resourceDetection" "eks" "enabled" false .collector) (dig "presets" "resourceDetection" "aks" "enabled" false .collector) (dig "presets" "resourceDetection" "gcp" "enabled" false .collector) (dig "presets" "resourceDetection" "k8s_api" "enabled" false .collector) }}
 {{- $config = (include "opentelemetry-kube-stack.collector.applyResourceDetectionConfig" (dict "collector" $collector) | fromYaml) -}}
 {{- $_ := set $collector "config" $config }}
 {{- end }}
@@ -157,10 +157,10 @@ OR helps them easily port prometheus to the otel-kube-stack chart with no change
 {{- define "opentelemetry-kube-stack.applyAnnotationDiscoveryConfig" -}}
 {{- $config := mustMergeOverwrite (include "opentelemetry-kube-stack.collector.annotationDiscoveryConfig" .collector  | fromYaml) .collector.config }}
 {{- $_ := set $config.service "extensions" (append ($config.service.extensions | default list)  "k8s_observer" | uniq)  }}
-{{- if .collector.presets.annotationDiscovery.logs.enabled }}
+{{- if (dig "presets" "annotationDiscovery" "logs" "enabled" false .collector) }}
 {{- $_ := set $config.service.pipelines.logs "receivers" (append $config.service.pipelines.logs.receivers "receiver_creator/logs" | uniq)  }}
 {{- end }}
-{{- if .collector.presets.annotationDiscovery.metrics.enabled }}
+{{- if (dig "presets" "annotationDiscovery" "metrics" "enabled" false .collector) }}
 {{- $_ := set $config.service.pipelines.metrics "receivers" (append $config.service.pipelines.metrics.receivers "receiver_creator/metrics" | uniq) }}
 {{- end }}
 {{- $config | toYaml }}
@@ -173,7 +173,7 @@ extensions:
     node: ${env:K8S_NODE_NAME}
 
 receivers:
-  {{- if .presets.annotationDiscovery.logs.enabled }}
+  {{- if (dig "presets" "annotationDiscovery" "logs" "enabled" false .) }}
   receiver_creator/logs:
     watch_observers:
       - k8s_observer
@@ -182,7 +182,7 @@ receivers:
       default_annotations:
         io.opentelemetry.discovery.logs/enabled: "true"
  {{- end }}
-  {{- if .presets.annotationDiscovery.metrics.enabled }}
+  {{- if (dig "presets" "annotationDiscovery" "metrics" "enabled" false .) }}
   receiver_creator/metrics:
     watch_observers:
       - k8s_observer
@@ -269,12 +269,12 @@ processors:
       - tag_name: k8s.app.component
         key: app.kubernetes.io/component
         from: pod
-      {{- if .presets.kubernetesAttributes.extractAllPodLabels }}
+      {{- if (dig "presets" "kubernetesAttributes" "extractAllPodLabels" false .) }}
       - tag_name: $$1
         key_regex: (.*)
         from: pod
       {{- end }}
-      {{- if .presets.kubernetesAttributes.extractAllPodAnnotations }}
+      {{- if (dig "presets" "kubernetesAttributes" "extractAllPodAnnotations" false .) }}
       annotations:
       - tag_name: $$1
         key_regex: (.*)
@@ -368,7 +368,7 @@ receivers:
 {{- $config := mustMergeOverwrite (include "opentelemetry-kube-stack.collector.clusterMetricsConfig" (dict "collector" .collector "namespace" .namespace "electorName" $electorName) | fromYaml) .collector.config }}
 {{- if and (dig "service" "pipelines" "metrics" false $config) (not (has "k8s_cluster" (dig "service" "pipelines" "metrics" "receivers" list $config))) }}
 {{- $_ := set $config.service.pipelines.metrics "receivers" (append ($config.service.pipelines.metrics.receivers | default list) "k8s_cluster" | uniq)  }}
-{{- $disableLeaderElection := .collector.presets.clusterMetrics.disableLeaderElection }}
+{{- $disableLeaderElection := (dig "presets" "clusterMetrics" "disableLeaderElection" false .collector) }}
 {{- if not $disableLeaderElection }}
 {{- $_ := set $config.service "extensions" (append ($config.service.extensions | default list) (printf "k8s_leader_elector/%s" $electorName) | uniq)  }}
 {{- end }}
@@ -377,7 +377,7 @@ receivers:
 {{- end }}
 
 {{- define "opentelemetry-kube-stack.collector.clusterMetricsConfig" -}}
-{{- $disableLeaderElection := .collector.presets.clusterMetrics.disableLeaderElection}}
+{{- $disableLeaderElection := (dig "presets" "clusterMetrics" "disableLeaderElection" false .collector)}}
 {{- if not $disableLeaderElection}}
 {{- include "opentelemetry-kube-stack.collector.leaderElectionConfig" (dict "name" .electorName "leaseName" "k8s.cluster.receiver.opentelemetry.io" "leaseNamespace" .namespace)}}
 {{- end}}
@@ -440,7 +440,7 @@ receivers:
 {{- if and (dig "service" "pipelines" "logs" false $config) (not (has $receiverName (dig "service" "pipelines" "logs" "receivers" list $config))) }}
 {{- $_ := set $config.service.pipelines.logs "receivers" (append ($config.service.pipelines.logs.receivers | default list) $receiverName | uniq)  }}
 {{- end }}
-{{- if .collector.presets.logsCollection.storeCheckpoints}}
+{{- if (dig "presets" "logsCollection" "storeCheckpoints" false .collector)}}
 {{- $_ := set $config.service "extensions" (append ($config.service.extensions | default list) "file_storage" | uniq)  }}
 {{- end }}
 {{- $config | toYaml }}
@@ -448,7 +448,7 @@ receivers:
 
 {{- define "opentelemetry-kube-stack.collector.logsCollectionConfig" -}}
 {{- $receiverName := get ._componentNames "filelog" }}
-{{- if .presets.logsCollection.storeCheckpoints }}
+{{- if (dig "presets" "logsCollection" "storeCheckpoints" false .) }}
 extensions:
   file_storage:
     directory: /var/lib/otelcol
@@ -457,7 +457,7 @@ receivers:
   {{ $receiverName }}:
     include:
       - /var/log/pods/*/*/*.log
-    {{- if .presets.logsCollection.includeCollectorLogs }}
+    {{- if (dig "presets" "logsCollection" "includeCollectorLogs" true .) }}
     exclude: []
     {{- else }}
     # Exclude collector container's logs. The file format is /var/log/pods/<namespace_name>_<pod_name>_<pod_uid>/<container_name>/<run_id>.log
@@ -467,7 +467,7 @@ receivers:
     start_at: end
     retry_on_failure:
         enabled: true
-    {{- if .presets.logsCollection.storeCheckpoints}}
+    {{- if (dig "presets" "logsCollection" "storeCheckpoints" false .) }}
     storage: file_storage
     {{- end }}
     include_file_path: true
@@ -476,7 +476,7 @@ receivers:
       # parse container logs
       - type: container
         id: container-parser
-        max_log_size: {{ .presets.logsCollection.maxRecombineLogSize }}
+        max_log_size: {{ dig "presets" "logsCollection" "maxRecombineLogSize" 102400 . }}
 {{- end }}
 
 {{- define "opentelemetry-kube-stack.collector.applyKubernetesEventsConfig" -}}
@@ -485,7 +485,7 @@ receivers:
 {{- $config := mustMergeOverwrite (include "opentelemetry-kube-stack.collector.kubernetesEventsConfig" (dict "collector" .collector "namespace" .namespace "electorName" $electorName "receiverName" $receiverName) | fromYaml) .collector.config }}
 {{- if and (dig "service" "pipelines" "logs" false $config) (not (has $receiverName (dig "service" "pipelines" "logs" "receivers" list $config))) }}
 {{- $_ := set $config.service.pipelines.logs "receivers" (append ($config.service.pipelines.logs.receivers | default list) $receiverName | uniq)  }}
-{{- $disableLeaderElection := .collector.presets.kubernetesEvents.disableLeaderElection }}
+{{- $disableLeaderElection := (dig "presets" "kubernetesEvents" "disableLeaderElection" false .collector) }}
 {{- if not $disableLeaderElection }}
 {{- $_ := set $config.service "extensions" (append ($config.service.extensions | default list) (printf "k8s_leader_elector/%s" $electorName) | uniq)  }}
 {{- end }}
@@ -494,7 +494,7 @@ receivers:
 {{- end }}
 
 {{- define "opentelemetry-kube-stack.collector.kubernetesEventsConfig" -}}
-{{- $disableLeaderElection := .collector.presets.kubernetesEvents.disableLeaderElection}}
+{{- $disableLeaderElection := (dig "presets" "kubernetesEvents" "disableLeaderElection" false .collector)}}
 {{- if not $disableLeaderElection}}
 {{- include "opentelemetry-kube-stack.collector.leaderElectionConfig" (dict "name" .electorName "leaseName" "k8s.objects.receiver.opentelemetry.io" "leaseNamespace" .namespace)}}
 {{- end}}
@@ -520,13 +520,13 @@ extensions:
 {{- end }}
 
 {{- define "opentelemetry-kube-stack.collector.applyKubernetesObjectsConfig" -}}
-{{- $disableLeaderElection := .collector.presets.kubernetesObjects.disableLeaderElection }}
+{{- $disableLeaderElection := (dig "presets" "kubernetesObjects" "disableLeaderElection" false .collector) }}
 {{- $useLeaderElection := and (eq .collector.mode "daemonset") (not $disableLeaderElection) }}
 {{- $electorName := "k8s_objects" }}
 {{- $receiverName := get .collector._componentNames "k8sobjects" }}
 {{- $ctx := mustMerge (dict "namespace" .namespace "useLeaderElection" $useLeaderElection "electorName" $electorName "receiverName" $receiverName) (dict "collector" .collector) }}
 {{- $objectsYaml := include "opentelemetry-kube-stack.collector.kubernetesObjectsConfig" $ctx | fromYaml }}
-{{- $newObjects := (index $objectsYaml.receivers $receiverName).objects }}
+{{- $newObjects := (index $objectsYaml.receivers $receiverName).objects | default list }}
 {{- $existingObjects := list }}
 {{- if .collector.config.receivers }}
 {{- if index .collector.config.receivers $receiverName }}
@@ -535,7 +535,7 @@ extensions:
 {{- end }}
 {{- end }}
 {{- end }}
-{{- $allObjects := concat $newObjects $existingObjects }}
+{{- $allObjects := concat ($newObjects | default list) $existingObjects }}
 {{- $config := mustMergeOverwrite (dict "service" (dict "pipelines" (dict "logs" (dict "receivers" list)))) $objectsYaml .collector.config }}
 {{- $_ := set (index $config.receivers $receiverName) "objects" $allObjects }}
 {{- $_ := set $config.service.pipelines.logs "receivers" (append $config.service.pipelines.logs.receivers $receiverName | uniq) }}
@@ -547,7 +547,7 @@ extensions:
 {{- end }}
 
 {{- define "opentelemetry-kube-stack.collector.kubernetesObjectsConfig" -}}
-{{- $preset := .collector.presets.kubernetesObjects -}}
+{{- $preset := dig "presets" "kubernetesObjects" (dict) .collector -}}
 {{- if .useLeaderElection }}
 {{- include "opentelemetry-kube-stack.collector.leaderElectionConfig" (dict "name" .electorName "leaseName" "k8s.objects.receiver.opentelemetry.io" "leaseNamespace" .namespace) }}
 {{- end }}
@@ -557,11 +557,11 @@ receivers:
     k8s_leader_elector: k8s_leader_elector/{{ .electorName }}
     {{- end }}
     objects:
-{{- if $preset.core.enabled }}
+{{- if (dig "core" "enabled" true $preset) }}
 {{- range list "namespaces" "pods" "nodes" "services" "serviceaccounts" }}
       - name: {{ . }}
         mode: pull
-{{- if $preset.watch }}
+{{- if (dig "watch" false $preset) }}
       - name: {{ . }}
         mode: watch
 {{- end }}
@@ -570,7 +570,7 @@ receivers:
       - name: {{ . }}
         mode: pull
         group: apps
-{{- if $preset.watch }}
+{{- if (dig "watch" false $preset) }}
       - name: {{ . }}
         mode: watch
         group: apps
@@ -580,31 +580,31 @@ receivers:
       - name: {{ . }}
         mode: pull
         group: batch
-{{- if $preset.watch }}
+{{- if (dig "watch" false $preset) }}
       - name: {{ . }}
         mode: watch
         group: batch
 {{- end }}
 {{- end }}
 {{- end }}
-{{- if $preset.rbac.enabled }}
+{{- if (dig "rbac" "enabled" true $preset) }}
 {{- range list "roles" "rolebindings" "clusterroles" "clusterrolebindings" }}
       - name: {{ . }}
         mode: pull
         group: rbac.authorization.k8s.io
-{{- if $preset.watch }}
+{{- if (dig "watch" false $preset) }}
       - name: {{ . }}
         mode: watch
         group: rbac.authorization.k8s.io
 {{- end }}
 {{- end }}
 {{- end }}
-{{- if $preset.storage.enabled }}
+{{- if (dig "storage" "enabled" true $preset) }}
 {{- range list "storageclasses" }}
       - name: {{ . }}
         mode: pull
         group: storage.k8s.io
-{{- if $preset.watch }}
+{{- if (dig "watch" false $preset) }}
       - name: {{ . }}
         mode: watch
         group: storage.k8s.io
@@ -613,59 +613,59 @@ receivers:
 {{- range list "persistentvolumes" "persistentvolumeclaims" }}
       - name: {{ . }}
         mode: pull
-{{- if $preset.watch }}
+{{- if (dig "watch" false $preset) }}
       - name: {{ . }}
         mode: watch
 {{- end }}
 {{- end }}
 {{- end }}
-{{- if $preset.networking.enabled }}
+{{- if (dig "networking" "enabled" true $preset) }}
 {{- range list "ingresses" "networkpolicies" }}
       - name: {{ . }}
         mode: pull
         group: networking.k8s.io
-{{- if $preset.watch }}
+{{- if (dig "watch" false $preset) }}
       - name: {{ . }}
         mode: watch
         group: networking.k8s.io
 {{- end }}
 {{- end }}
 {{- end }}
-{{- if $preset.autoscaling.enabled }}
+{{- if (dig "autoscaling" "enabled" true $preset) }}
       - name: horizontalpodautoscalers
         mode: pull
         group: autoscaling
-{{- if $preset.watch }}
+{{- if (dig "watch" false $preset) }}
       - name: horizontalpodautoscalers
         mode: watch
         group: autoscaling
 {{- end }}
-{{- if $preset.autoscaling.vpa.enabled }}
+{{- if (dig "autoscaling" "vpa" "enabled" false $preset) }}
       - name: verticalpodautoscalers
         mode: pull
         group: autoscaling.k8s.io
-{{- if $preset.watch }}
+{{- if (dig "watch" false $preset) }}
       - name: verticalpodautoscalers
         mode: watch
         group: autoscaling.k8s.io
 {{- end }}
 {{- end }}
 {{- end }}
-{{- if $preset.policy.enabled }}
+{{- if (dig "policy" "enabled" true $preset) }}
       - name: poddisruptionbudgets
         mode: pull
         group: policy
-{{- if $preset.watch }}
+{{- if (dig "watch" false $preset) }}
       - name: poddisruptionbudgets
         mode: watch
         group: policy
 {{- end }}
 {{- end }}
-{{- if $preset.apiExtensions.enabled }}
+{{- if (dig "apiExtensions" "enabled" true $preset) }}
       - name: customresourcedefinitions
         mode: pull
         group: apiextensions.k8s.io
-{{- if $preset.watch }}
+{{- if (dig "watch" false $preset) }}
       - name: customresourcedefinitions
         mode: watch
         group: apiextensions.k8s.io
@@ -681,29 +681,29 @@ receivers:
 {{- $resourceDetectionProcessor := get $processors $processorName | default dict }}
 {{- $detectors := get $resourceDetectionProcessor "detectors" | default list }}
 
-{{- if .collector.presets.resourceDetection.env.enabled }}
+{{- if (dig "presets" "resourceDetection" "env" "enabled" false .collector) }}
 {{- $detectors = append $detectors "env" | uniq }}
 {{- end }}
 
-{{- if .collector.presets.resourceDetection.aks.enabled }}
+{{- if (dig "presets" "resourceDetection" "aks" "enabled" false .collector) }}
 {{- $aksResourceDetectionProcessor := include "opentelemetry-kube-stack.collector.resourceDetectionAksDetectorConfig" . | fromYaml }}
 {{- $resourceDetectionProcessor = mustMergeOverwrite $resourceDetectionProcessor $aksResourceDetectionProcessor }}
 {{- $detectors = append $detectors "aks" | uniq }}
 {{- end }}
 
-{{- if .collector.presets.resourceDetection.eks.enabled }}
+{{- if (dig "presets" "resourceDetection" "eks" "enabled" false .collector) }}
 {{- $eksResourceDetectionProcessor := include "opentelemetry-kube-stack.collector.resourceDetectionEksDetectorConfig" . | fromYaml }}
 {{- $resourceDetectionProcessor = mustMergeOverwrite $resourceDetectionProcessor $eksResourceDetectionProcessor }}
 {{- $detectors = append $detectors "eks" | uniq }}
 {{- end }}
 
-{{- if .collector.presets.resourceDetection.gcp.enabled }}
+{{- if (dig "presets" "resourceDetection" "gcp" "enabled" false .collector) }}
 {{- $gcpResourceDetectionProcessor := include "opentelemetry-kube-stack.collector.resourceDetectionGcpDetectorConfig" . | fromYaml }}
 {{- $resourceDetectionProcessor = mustMergeOverwrite $resourceDetectionProcessor $gcpResourceDetectionProcessor }}
 {{- $detectors = append $detectors "gcp" | uniq }}
 {{- end }}
 
-{{- if .collector.presets.resourceDetection.k8s_api.enabled }}
+{{- if (dig "presets" "resourceDetection" "k8s_api" "enabled" false .collector) }}
 {{- $detectors = append $detectors "k8s_api" | uniq }}
 {{- end }}
 {{- $_ := set $resourceDetectionProcessor "detectors" $detectors }}
@@ -748,11 +748,11 @@ Validates the `presets.prometheus.*` family of presets:
     a collector pod is scheduled per node.
 */}}
 {{- define "opentelemetry-kube-stack.assertPrometheusPresets" -}}
-{{- $prom := .collector.presets.prometheus }}
+{{- $prom := dig "presets" "prometheus" (dict) .collector }}
 {{- $enabled := list }}
-{{- if $prom.nodeExporter.enabled }}{{- $enabled = append $enabled "nodeExporter" }}{{- end }}
-{{- if $prom.cadvisor.enabled }}{{- $enabled = append $enabled "cadvisor" }}{{- end }}
-{{- if $prom.podAnnotations.enabled }}{{- $enabled = append $enabled "podAnnotations" }}{{- end }}
+{{- if (dig "nodeExporter" "enabled" false $prom) }}{{- $enabled = append $enabled "nodeExporter" }}{{- end }}
+{{- if (dig "cadvisor" "enabled" false $prom) }}{{- $enabled = append $enabled "cadvisor" }}{{- end }}
+{{- if (dig "podAnnotations" "enabled" false $prom) }}{{- $enabled = append $enabled "podAnnotations" }}{{- end }}
 {{- if $enabled }}
 {{- $collectorName := .collector.suffix | default "unnamed" }}
 {{- $enabledList := join ", " $enabled }}
@@ -783,24 +783,24 @@ the metrics pipeline. Args:
 {{- end }}
 
 {{- define "opentelemetry-kube-stack.collector.prometheusNodeExporterConfig" -}}
-{{- $cfg := .presets.prometheus.nodeExporter }}
+{{- $cfg := dig "presets" "prometheus" "nodeExporter" (dict) . }}
 receivers:
   prometheus/node_exporter:
     config:
       scrape_configs:
         - job_name: node-exporter
-          scrape_interval: {{ $cfg.scrapeInterval }}
-          scrape_timeout: {{ $cfg.scrapeTimeout }}
+          scrape_interval: {{ (dig "scrapeInterval" "30s" $cfg) }}
+          scrape_timeout: {{ (dig "scrapeTimeout" "10s" $cfg) }}
           static_configs:
             - targets:
-                - ${env:OTEL_K8S_NODE_IP}:{{ $cfg.port }}
+                - ${env:OTEL_K8S_NODE_IP}:{{ (dig "port" 9100 $cfg) }}
           relabel_configs:
             - target_label: node
               replacement: ${env:OTEL_K8S_NODE_NAME}
 {{- end }}
 
 {{- define "opentelemetry-kube-stack.collector.prometheusCadvisorConfig" -}}
-{{- $cfg := .presets.prometheus.cadvisor }}
+{{- $cfg := dig "presets" "prometheus" "cadvisor" (dict) . }}
 receivers:
   prometheus/cadvisor:
     config:
@@ -808,8 +808,8 @@ receivers:
         - job_name: kubelet
           scheme: https
           metrics_path: /metrics/cadvisor
-          scrape_interval: {{ $cfg.scrapeInterval }}
-          scrape_timeout: {{ $cfg.scrapeTimeout }}
+          scrape_interval: {{ (dig "scrapeInterval" "30s" $cfg) }}
+          scrape_timeout: {{ (dig "scrapeTimeout" "10s" $cfg) }}
           authorization:
             type: Bearer
             credentials_file: /var/run/secrets/kubernetes.io/serviceaccount/token
@@ -818,7 +818,7 @@ receivers:
             insecure_skip_verify: true
           static_configs:
             - targets:
-                - ${env:OTEL_K8S_NODE_IP}:{{ $cfg.port }}
+                - ${env:OTEL_K8S_NODE_IP}:{{ (dig "port" 10250 $cfg) }}
           relabel_configs:
             - target_label: node
               replacement: ${env:OTEL_K8S_NODE_NAME}
@@ -848,14 +848,14 @@ receivers:
 {{- end }}
 
 {{- define "opentelemetry-kube-stack.collector.prometheusPodAnnotationsConfig" -}}
-{{- $cfg := .presets.prometheus.podAnnotations }}
+{{- $cfg := dig "presets" "prometheus" "podAnnotations" (dict) . }}
 receivers:
   prometheus/pod_annotations:
     config:
       scrape_configs:
         - job_name: kubernetes-pods
-          scrape_interval: {{ $cfg.scrapeInterval }}
-          scrape_timeout: {{ $cfg.scrapeTimeout }}
+          scrape_interval: {{ (dig "scrapeInterval" "30s" $cfg) }}
+          scrape_timeout: {{ (dig "scrapeTimeout" "10s" $cfg) }}
           kubernetes_sd_configs:
             - role: pod
               selectors:

--- a/charts/opentelemetry-kube-stack/templates/_helpers.tpl
+++ b/charts/opentelemetry-kube-stack/templates/_helpers.tpl
@@ -179,15 +179,13 @@ Optionally include the RBAC for the k8sCluster receiver
 {{- $useLeaderElection := false }}
 {{- $k8sApiEnabled := false }}
 {{ range $_, $collector := $.Values.collectors -}}
-{{- if $.Values.defaultCRConfig.enabled }}
-{{- $collector = (mergeOverwrite (deepCopy $.Values.defaultCRConfig) $collector) }}
-{{- end }}
-{{- $clusterMetricsEnabled = (any $clusterMetricsEnabled (dig "config" "receivers" "k8s_cluster" false $collector)) }}
+{{- $collector = (include "opentelemetry-kube-stack.mergeCollector" (dict "root" $ "collector" $collector) | fromYaml) }}
+{{- $clusterMetricsEnabled = (any $clusterMetricsEnabled (dig "receivers" "k8s_cluster" false ($collector.config | default dict))) }}
 {{- if (dig "presets" "clusterMetrics" "enabled" false $collector) }}
 {{- $clusterMetricsEnabled = true }}
 {{- $useLeaderElection = (any $useLeaderElection (not (dig "presets" "clusterMetrics" "disableLeaderElection" false $collector))) }}
 {{- end }}
-{{- $eventsEnabled = (any $eventsEnabled (dig "config" "receivers" "k8s_cluster" false $collector)) }}
+{{- $eventsEnabled = (any $eventsEnabled (dig "receivers" "k8s_cluster" false ($collector.config | default dict))) }}
 {{- if (dig "presets" "kubernetesEvents" "enabled" false $collector) }}
 {{- $eventsEnabled = true }}
 {{- $useLeaderElection = (any $useLeaderElection (not (dig "presets" "kubernetesEvents" "disableLeaderElection" false $collector))) }}
@@ -392,9 +390,7 @@ users migrate to the current lower_snake_case names.
 {{- $warnings := list }}
 {{- $renames := include "opentelemetry-kube-stack.collector.componentRenames" . | fromYamlArray }}
 {{- range $collectorName, $collector := .Values.collectors }}
-{{- if $.Values.defaultCRConfig.enabled }}
-{{- $collector = (mergeOverwrite (deepCopy $.Values.defaultCRConfig) $collector) }}
-{{- end }}
+{{- $collector = (include "opentelemetry-kube-stack.mergeCollector" (dict "root" $ "collector" $collector) | fromYaml) }}
 {{- if $collector.enabled }}
 {{- $config := deepCopy ($collector.config | default dict) }}
 {{- range $rename := $renames }}
@@ -465,6 +461,34 @@ Helpers for prometheus servicemonitors
   {{- $userValue := index . 3 -}}
   {{- include "opentelemetry-kube-stack.kubeVersionDefaultValue" (list $values ">= 1.23-0" $insecure $secure $userValue) -}}
 {{- end -}}
+
+{{/*
+Merges defaultCRConfig into a collector, respecting the collector's
+inheritDefaultCRConfig flag. Returns the merged collector as YAML.
+Callers must use fromYaml to get a dict.
+- inheritDefaultCRConfig: true (default): full mergeOverwrite of defaultCRConfig onto the collector.
+- inheritDefaultCRConfig: false: the collector inherits structural defaults (env,
+  resources, image, clusterRoleBinding, ...) but not the shared config,
+  presets, scrape_configs_file, or targetAllocator.enabled. The collector
+  defines its own config and can only use the presets it explicitly enables.
+*/}}
+{{- define "opentelemetry-kube-stack.mergeCollector" -}}
+{{- $root := .root -}}
+{{- $collector := deepCopy .collector -}}
+{{- $isolated := and $root.Values.defaultCRConfig.enabled (eq (dig "inheritDefaultCRConfig" true $collector) false) -}}
+{{- if and $root.Values.defaultCRConfig.enabled (not $isolated) -}}
+{{- $collector = (mergeOverwrite (deepCopy $root.Values.defaultCRConfig) $collector) -}}
+{{- else if $root.Values.defaultCRConfig.enabled -}}
+{{- $base := deepCopy $root.Values.defaultCRConfig -}}
+{{- $_ := unset $base "config" -}}
+{{- $_ := unset $base "presets" -}}
+{{- $_ := unset $base "scrape_configs_file" -}}
+{{- $_ := unset $base "targetAllocator" -}}
+{{- $collector = (mergeOverwrite $base $collector) -}}
+
+{{- end -}}
+{{- $collector | toYaml -}}
+{{- end }}
 
 {{/* Sets default scrape limits for servicemonitor */}}
 {{- define "opentelemetry-kube-stack.servicemonitor.scrapeLimits" -}}

--- a/charts/opentelemetry-kube-stack/templates/clusterrole.yaml
+++ b/charts/opentelemetry-kube-stack/templates/clusterrole.yaml
@@ -59,9 +59,7 @@ rules:
 {{- end }}
 {{ range $_, $collector := $.Values.collectors -}}
 {{- if $collector.enabled -}}
-{{- if $.Values.defaultCRConfig.enabled }}
-{{- $collector = (mergeOverwrite (deepCopy $.Values.defaultCRConfig) $collector) }}
-{{- end }}
+{{- $collector = (include "opentelemetry-kube-stack.mergeCollector" (dict "root" $ "collector" $collector) | fromYaml) }}
 {{- $merged := (dict "Template" $.Template "Files" $.Files "Chart" $.Chart "clusterRole" $.Values.clusterRole "collector" $collector "Release" $.Release "fullnameOverride" $.Values.fullnameOverride "presets" $.Values.presets) }}
 {{- $fullname := (include "opentelemetry-kube-stack.collectorFullname" $merged) }}
 {{- if and $collector.enabled $collector.clusterRoleBinding.enabled }}
@@ -83,9 +81,9 @@ subjects:
   name: "{{ $fullname }}-collector"
 {{- end }}
   namespace: {{ $.Release.Namespace }}
-{{- if $collector.targetAllocator.enabled }}
+{{- if (dig "targetAllocator" "enabled" false $collector) }}
 - kind: ServiceAccount
-{{- if $collector.targetAllocator.serviceAccount }}
+{{- if (dig "targetAllocator" "serviceAccount" "" $collector) }}
   name: "{{ $collector.targetAllocator.serviceAccount }}"
 {{- else }}
   name: {{ $fullname }}-targetallocator

--- a/charts/opentelemetry-kube-stack/templates/collector.yaml
+++ b/charts/opentelemetry-kube-stack/templates/collector.yaml
@@ -1,8 +1,6 @@
 {{ range $_, $collector := $.Values.collectors -}}
 {{- if $collector.enabled -}}
-{{- if $.Values.defaultCRConfig.enabled }}
-{{- $collector = (mergeOverwrite (deepCopy $.Values.defaultCRConfig) $collector) }}
-{{- end }}
+{{- $collector = (include "opentelemetry-kube-stack.mergeCollector" (dict "root" $ "collector" $collector) | fromYaml) }}
 {{- $merged := (dict "Template" $.Template "Files" $.Files "Chart" $.Chart "clusterRole" $.Values.clusterRole "collector" $collector "Release" $.Release "fullnameOverride" $.Values.fullnameOverride "presets" $.Values.presets "namespace" (include "opentelemetry-kube-stack.namespace" $)  "kubelet" $.Values.kubelet "clusterName" $.Values.clusterName "rewriteDeprecatedComponentNames" $.Values.rewriteDeprecatedComponentNames) }}
 {{- $fullname := (include "opentelemetry-kube-stack.collectorFullname" $merged) }}
 ---
@@ -75,7 +73,7 @@ spec:
   {{- toYaml . | nindent 4}}
   {{- end }}
   securityContext:
-  {{- if and (not ($collector.securityContext)) ($collector.presets.logsCollection.storeCheckpoints) }}
+  {{- if and (not ($collector.securityContext)) ((dig "presets" "logsCollection" "storeCheckpoints" false $collector)) }}
     runAsUser: 0
     runAsGroup: 0
   {{- else -}}
@@ -135,9 +133,9 @@ spec:
   {{- toYaml . | nindent 4}}
   {{- end }}
   {{- end }}
-  {{- if or ($collector.presets.logsCollection.enabled) ($collector.presets.logsCollection.storeCheckpoints) ($collector.presets.hostMetrics.enabled) ($collector.volumeMounts) }}
+  {{- if or ((dig "presets" "logsCollection" "enabled" false $collector)) ((dig "presets" "logsCollection" "storeCheckpoints" false $collector)) ((dig "presets" "hostMetrics" "enabled" false $collector)) ($collector.volumeMounts) }}
   volumeMounts:
-  {{- if $collector.presets.logsCollection.enabled }}
+  {{- if (dig "presets" "logsCollection" "enabled" false $collector) }}
   - name: varlogpods
     mountPath: /var/log/pods
     readOnly: true
@@ -145,11 +143,11 @@ spec:
     mountPath: /var/lib/docker/containers
     readOnly: true
   {{- end }}
-  {{- if $collector.presets.logsCollection.storeCheckpoints}}
+  {{- if (dig "presets" "logsCollection" "storeCheckpoints" false $collector)}}
   - name: varlibotelcol
     mountPath: /var/lib/otelcol
   {{- end }}
-  {{- if $collector.presets.hostMetrics.enabled }}
+  {{- if (dig "presets" "hostMetrics" "enabled" false $collector) }}
   - name: hostfs
     mountPath: /hostfs
     readOnly: true
@@ -206,13 +204,13 @@ spec:
   tolerations:
   {{- toYaml . | nindent 4 }}
   {{- end }}
-  {{- if or ($collector.presets.logsCollection.enabled) ($collector.presets.logsCollection.storeCheckpoints) ($collector.presets.hostMetrics.enabled) ($collector.volumes) }}
+  {{- if or ((dig "presets" "logsCollection" "enabled" false $collector)) ((dig "presets" "logsCollection" "storeCheckpoints" false $collector)) ((dig "presets" "hostMetrics" "enabled" false $collector)) ($collector.volumes) }}
   volumes:
-  {{- if $collector.presets.logsCollection.enabled }}
+  {{- if (dig "presets" "logsCollection" "enabled" false $collector) }}
   - name: varlogpods
     hostPath:
       path: /var/log/pods
-  {{- if $collector.presets.logsCollection.storeCheckpoints }}
+  {{- if (dig "presets" "logsCollection" "storeCheckpoints" false $collector) }}
   - name: varlibotelcol
     hostPath:
       path: /var/lib/otelcol
@@ -222,7 +220,7 @@ spec:
     hostPath:
       path: /var/lib/docker/containers
   {{- end }}
-  {{- if $collector.presets.hostMetrics.enabled }}
+  {{- if (dig "presets" "hostMetrics" "enabled" false $collector) }}
   - name: hostfs
     hostPath:
       path: /
@@ -233,11 +231,11 @@ spec:
   {{- end }}
   {{- with $collector.initContainers }}
   initContainers:
-  {{- toYaml . | nindent 4 }}
+  {{- tpl (toYaml .) $merged | nindent 4 }}
   {{- end }}
   {{- with $collector.additionalContainers }}
   additionalContainers:
-  {{- toYaml . | nindent 4 }}
+  {{- tpl (toYaml .) $merged | nindent 4 }}
   {{- end }}
   {{- with $collector.topologySpreadConstraints }}
   topologySpreadConstraints:

--- a/charts/opentelemetry-kube-stack/values.schema.json
+++ b/charts/opentelemetry-kube-stack/values.schema.json
@@ -1948,6 +1948,10 @@
         },
         "deploymentUpdateStrategy": {
           "$ref": "#/$defs/DeploymentUpdateStrategy"
+        },
+        "inheritDefaultCRConfig": {
+          "type": "boolean",
+          "description": "When false, the collector does not inherit the shared config, presets, or scrape_configs_file from defaultCRConfig, and targetAllocator. It defines its own config and only the presets it explicitly enables. Other defaults (env, resources, image, etc.) still apply and can be overridden. Required for collectors running a dedicated distribution whose binary does not include the components declared in the shared defaultCRConfig.config."
         }
       },
       "additionalProperties": true,

--- a/charts/opentelemetry-kube-stack/values.yaml
+++ b/charts/opentelemetry-kube-stack/values.yaml
@@ -372,8 +372,7 @@ defaultCRConfig:
   #   type: RollingUpdate
 
   # Retention policy for the PersistentVolumeClaim https://kubernetes.io/docs/concepts/workloads/controllers/statefulset/#persistentvolumeclaim-retention
-  persistentVolumeClaimRetentionPolicy:
-    {}
+  persistentVolumeClaimRetentionPolicy: {}
     # whenDeleted: Retain
     # whenScaled: Retain
 
@@ -421,12 +420,15 @@ defaultCRConfig:
   #   configMap:
   #     name: config
 
-  # Init containers for the collector
+  # Init containers for the collector. Rendered as Helm templates with the
+  # merged collector context, so entries can reference collector fields, e.g.
+  # image: "{{ .collector.image.repository }}:{{ .collector.image.tag }}".
   initContainers: []
   # - name: init-nginx
   #   image: nginx
 
-  # Additional containers for the collector
+  # Additional containers for the collector. Rendered as Helm templates with
+  # the merged collector context, like initContainers.
   additionalContainers: []
   # - name: additional-container
   #   image: busybox
@@ -633,6 +635,18 @@ defaultCRConfig:
 #     enabled: true
 #     name: "example"
 # Each collector configuration is layered on top of the `defaultCRConfig`, overriding a default if set.
+# Set inheritDefaultCRConfig: false on a collector so it does not
+# inherit the shared config and the enabled presets from defaultCRConfig;
+# the collector then defines its own config and only the presets
+# it explicitly enables. Other defaults (mode, image, clusterRoleBinding,
+# env, resources, ...) still apply and can be overridden as usual.
+# This is required when the collector runs a
+# dedicated distribution image (e.g. an eBPF profiler) whose binary
+# does not include the components declared in the shared
+# defaultCRConfig.config, and whose preset defaults may inject
+# receivers or processors that the distribution binary does not ship.
+# scrape_configs_file and targetAllocator are also excluded from inheritance with this configuration;
+# define them locally if needed.
 # This configuration allows for multiple layers of overrides for different clusters. For example, you could
 # create a collector called test with an OTLP exporter in your values.yaml, and then override the endpoint's
 # destination in a file called values-staging.yaml.


### PR DESCRIPTION
#### Description

We want to port the ebpf profiler effort introduced in https://github.com/open-telemetry/opentelemetry-helm-charts/pull/2287 and https://github.com/open-telemetry/opentelemetry-helm-charts/pull/2126 and  to the `kube-stack `chart.

The profiling receiver runs as a dedicated distribution (`otelcol-ebpf-profiler`), not as part of the general-purpose k8s distro. As discussed in https://github.com/open-telemetry/opentelemetry-helm-charts/pull/2126#discussion_r3065602137, the eBPF profiler needs hostPID and elevated capabilities, so bundling it with the collector that handles metrics, traces and logs would grant those privileges to that same collector. The dedicated distribution also ships a subset of the components.

`kube-stack` currently merges `defaultCRConfig` into every collector, and that config is written for the general purpose distro. Deploying a profiler collector today crashes it at startup, on components it inherited but cannot build.

This PR adds `collectors.<name>.inheritDefaultCRConfig` (default `true`). When `false`, the collector no longer inherits `config`, `presets`, `scrape_configs_file` and `targetAllocator` from `defaultCRConfig`. It keeps the other defaults (`mode`, `image`, `env`, `resources`, `clusterRoleBinding`, ...) and defines its own config. The profiling preset itself lands in a follow-up PR stacked on this one.

Rest of the diff is groundwork for that option:
 - merge logic now lives in one helper, `opentelemetry-kube-stack.mergeCollector`.
 - presets can now be absent from a collector, so preset lookups use dig with the documented defaults instead of direct field access
 - config can be absent too, so the `k8s_cluster` receiver detection read it through `config | default dict`

#### Authorship

- [x] I, a human, wrote this pull request description myself.
