### PR TITLE
feat(opentelemetry-demo): enable TRACELOOP_TRACE_CONTENT for agent LLM tracing

### DIFF
--- a/charts/opentelemetry-demo/Chart.yaml
+++ b/charts/opentelemetry-demo/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 type: application
 name: opentelemetry-demo
-version: 0.41.0
+version: 0.41.1
 description: opentelemetry demo helm chart
 home: https://opentelemetry.io/
 sources:

--- a/charts/opentelemetry-demo/values.yaml
+++ b/charts/opentelemetry-demo/values.yaml
@@ -261,6 +261,8 @@ components:
         value: "True"
       - name: VCR_MATCH_THRESHOLD
         value: "0.85"
+      - name: TRACELOOP_TRACE_CONTENT
+        value: "true"
       - name: LLM_TLS_VERIFY
         value: "True"
       - name: APPLICATION_ENDPOINT


### PR DESCRIPTION
#### Description

Adds `TRACELOOP_TRACE_CONTENT=true` to the agent's env vars in the
`opentelemetry-demo` chart's `values.yaml`, so LLM prompt/response content is
captured in traces. Bumps chart patch version (0.41.0 -> 0.41.1).

Matches open-telemetry/opentelemetry-demo#3960.

#### Link to tracking issue
Fixes

#### Authorship

- [x] I, a human, wrote this pull request description myself.