### PR TITLE
[chore]: move some workflows to less-requested runners

### DIFF
--- a/.github/workflows/demo-test.yaml
+++ b/.github/workflows/demo-test.yaml
@@ -38,7 +38,7 @@ jobs:
 
   demo-test:
     if: always()
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-slim
     needs: [demo-test-matrix]
     steps:
       - name: Check matrix result

--- a/.github/workflows/ebpf-test.yaml
+++ b/.github/workflows/ebpf-test.yaml
@@ -46,7 +46,7 @@ jobs:
 
   ebpf-test:
     if: always()
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-slim
     needs: [ebpf-test-matrix]
     steps:
       - name: Check matrix result

--- a/.github/workflows/fossa.yml
+++ b/.github/workflows/fossa.yml
@@ -10,7 +10,7 @@ permissions:
 
 jobs:
   fossa:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-slim
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
 

--- a/.github/workflows/kube-stack-test.yaml
+++ b/.github/workflows/kube-stack-test.yaml
@@ -42,7 +42,7 @@ jobs:
 
   opentelemetry-kube-stack-test:
     if: always()
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-slim
     needs: [kube-stack-test-matrix]
     steps:
       - name: Check matrix result

--- a/.github/workflows/lint.yaml
+++ b/.github/workflows/lint.yaml
@@ -10,7 +10,7 @@ permissions:
 
 jobs:
   lint-test-matrix:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-slim
     strategy:
       matrix:
         helm-version:
@@ -39,7 +39,7 @@ jobs:
 
   lint-test:
     if: always()
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-slim
     needs: [lint-test-matrix]
     steps:
       - name: Check matrix result

--- a/.github/workflows/operator-test.yaml
+++ b/.github/workflows/operator-test.yaml
@@ -85,7 +85,7 @@ jobs:
 
   operator-test:
     if: always()
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-slim
     needs: [operator-test-matrix]
     steps:
       - name: Check matrix result
@@ -166,7 +166,7 @@ jobs:
 
   operator-test-no-certmanager:
     if: always()
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-slim
     needs: [operator-test-no-certmanager-matrix]
     steps:
       - name: Check matrix result

--- a/.github/workflows/pre-commit.yaml
+++ b/.github/workflows/pre-commit.yaml
@@ -10,7 +10,7 @@ permissions:
 
 jobs:
   pre-commit:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-slim
     steps:
     - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
     - uses: actions/setup-python@5fda3b95a4ea91299a34e894583c3862153e4b97 # v7.0.0

--- a/.github/workflows/stale.yaml
+++ b/.github/workflows/stale.yaml
@@ -12,7 +12,7 @@ jobs:
     permissions:
       issues: write  # for actions/stale to close stale issues
       pull-requests: write  # for actions/stale to close stale PRs
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-slim
     steps:
       - uses: actions/stale@4391f3da665fdf50b6810c1a66712fb9ba21aa93 # v11.0.0
         with:

--- a/.github/workflows/sync-readme.yaml
+++ b/.github/workflows/sync-readme.yaml
@@ -14,7 +14,7 @@ jobs:
     permissions:
       contents: write
 
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-slim
     steps:
       - name: Checkout main
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1

--- a/.github/workflows/ta-test.yaml
+++ b/.github/workflows/ta-test.yaml
@@ -38,7 +38,7 @@ jobs:
 
   ta-test:
     if: always()
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-slim
     needs: [ta-test-matrix]
     steps:
       - name: Check matrix result

--- a/.github/workflows/update-chart-app-version.yaml
+++ b/.github/workflows/update-chart-app-version.yaml
@@ -62,7 +62,7 @@ jobs:
     permissions:
       contents: write
       pull-requests: write
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-slim
     steps:
       - name: Checkout
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1


### PR DESCRIPTION
#### Description

Our jobs queue for a long time waiting for runners. Collector core/contrib saw improvements by requesting smaller, less-requested runners for jobs that don't need a lot of compute. this PR updates our workflows to do the same.

#### Authorship

- [x] I, a human, wrote this pull request description myself.
