### PR TITLE
fix(opentelemetry-collector): Hash only the ConfigMap data in checksum/config

### DIFF
--- a/charts/opentelemetry-collector/Chart.yaml
+++ b/charts/opentelemetry-collector/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 name: opentelemetry-collector
-version: 0.173.0
+version: 0.173.1
 description: OpenTelemetry Collector Helm chart for Kubernetes
 type: application
 home: https://opentelemetry.io/

--- a/charts/opentelemetry-collector/examples/alternate-config/rendered/clusterrole.yaml
+++ b/charts/opentelemetry-collector/examples/alternate-config/rendered/clusterrole.yaml
@@ -5,7 +5,7 @@ kind: ClusterRole
 metadata:
   name: example-opentelemetry-collector
   labels:
-    helm.sh/chart: opentelemetry-collector-0.173.0
+    helm.sh/chart: opentelemetry-collector-0.173.1
     app.kubernetes.io/name: opentelemetry-collector
     app.kubernetes.io/instance: example
     app.kubernetes.io/version: "0.160.0"

--- a/charts/opentelemetry-collector/examples/alternate-config/rendered/clusterrolebinding.yaml
+++ b/charts/opentelemetry-collector/examples/alternate-config/rendered/clusterrolebinding.yaml
@@ -5,7 +5,7 @@ kind: ClusterRoleBinding
 metadata:
   name: example-opentelemetry-collector
   labels:
-    helm.sh/chart: opentelemetry-collector-0.173.0
+    helm.sh/chart: opentelemetry-collector-0.173.1
     app.kubernetes.io/name: opentelemetry-collector
     app.kubernetes.io/instance: example
     app.kubernetes.io/version: "0.160.0"

--- a/charts/opentelemetry-collector/examples/alternate-config/rendered/configmap.yaml
+++ b/charts/opentelemetry-collector/examples/alternate-config/rendered/configmap.yaml
@@ -6,7 +6,7 @@ metadata:
   name: example-opentelemetry-collector
   namespace: default
   labels:
-    helm.sh/chart: opentelemetry-collector-0.173.0
+    helm.sh/chart: opentelemetry-collector-0.173.1
     app.kubernetes.io/name: opentelemetry-collector
     app.kubernetes.io/instance: example
     app.kubernetes.io/version: "0.160.0"

--- a/charts/opentelemetry-collector/examples/alternate-config/rendered/deployment.yaml
+++ b/charts/opentelemetry-collector/examples/alternate-config/rendered/deployment.yaml
@@ -6,7 +6,7 @@ metadata:
   name: example-opentelemetry-collector
   namespace: default
   labels:
-    helm.sh/chart: opentelemetry-collector-0.173.0
+    helm.sh/chart: opentelemetry-collector-0.173.1
     app.kubernetes.io/name: opentelemetry-collector
     app.kubernetes.io/instance: example
     app.kubernetes.io/version: "0.160.0"
@@ -26,7 +26,7 @@ spec:
   template:
     metadata:
       annotations:
-        checksum/config: 48d5b889ba858d68fbdc371a8ae5a17c8788935d1d2449068fcd7b2aa70c7eab
+        checksum/config: f694dd0389378ac16f708b8e731edf0a9135185739537b3ab40339cb6c7e76e0
         
       labels:
         app.kubernetes.io/name: opentelemetry-collector

--- a/charts/opentelemetry-collector/examples/alternate-config/rendered/service.yaml
+++ b/charts/opentelemetry-collector/examples/alternate-config/rendered/service.yaml
@@ -6,7 +6,7 @@ metadata:
   name: example-opentelemetry-collector
   namespace: default
   labels:
-    helm.sh/chart: opentelemetry-collector-0.173.0
+    helm.sh/chart: opentelemetry-collector-0.173.1
     app.kubernetes.io/name: opentelemetry-collector
     app.kubernetes.io/instance: example
     app.kubernetes.io/version: "0.160.0"

--- a/charts/opentelemetry-collector/examples/alternate-config/rendered/serviceaccount.yaml
+++ b/charts/opentelemetry-collector/examples/alternate-config/rendered/serviceaccount.yaml
@@ -6,7 +6,7 @@ metadata:
   name: example-opentelemetry-collector
   namespace: default
   labels:
-    helm.sh/chart: opentelemetry-collector-0.173.0
+    helm.sh/chart: opentelemetry-collector-0.173.1
     app.kubernetes.io/name: opentelemetry-collector
     app.kubernetes.io/instance: example
     app.kubernetes.io/version: "0.160.0"

--- a/charts/opentelemetry-collector/examples/custom-metrics-hpa/rendered/configmap.yaml
+++ b/charts/opentelemetry-collector/examples/custom-metrics-hpa/rendered/configmap.yaml
@@ -6,7 +6,7 @@ metadata:
   name: example-opentelemetry-collector
   namespace: default
   labels:
-    helm.sh/chart: opentelemetry-collector-0.173.0
+    helm.sh/chart: opentelemetry-collector-0.173.1
     app.kubernetes.io/name: opentelemetry-collector
     app.kubernetes.io/instance: example
     app.kubernetes.io/version: "0.160.0"

--- a/charts/opentelemetry-collector/examples/custom-metrics-hpa/rendered/deployment.yaml
+++ b/charts/opentelemetry-collector/examples/custom-metrics-hpa/rendered/deployment.yaml
@@ -6,7 +6,7 @@ metadata:
   name: example-opentelemetry-collector
   namespace: default
   labels:
-    helm.sh/chart: opentelemetry-collector-0.173.0
+    helm.sh/chart: opentelemetry-collector-0.173.1
     app.kubernetes.io/name: opentelemetry-collector
     app.kubernetes.io/instance: example
     app.kubernetes.io/version: "0.160.0"
@@ -25,7 +25,7 @@ spec:
   template:
     metadata:
       annotations:
-        checksum/config: 7c0bf33c0be34f870c3af2532a360fc9844bd75080b6f0e08f52e971ed6b50a3
+        checksum/config: e4ff59dfcded1b562c6b8ef93fad7a7c6954b8d279b8599f87252ae1caa773e2
         
       labels:
         app.kubernetes.io/name: opentelemetry-collector

--- a/charts/opentelemetry-collector/examples/custom-metrics-hpa/rendered/hpa.yaml
+++ b/charts/opentelemetry-collector/examples/custom-metrics-hpa/rendered/hpa.yaml
@@ -6,7 +6,7 @@ metadata:
   name: example-opentelemetry-collector
   namespace: default
   labels:
-    helm.sh/chart: opentelemetry-collector-0.173.0
+    helm.sh/chart: opentelemetry-collector-0.173.1
     app.kubernetes.io/name: opentelemetry-collector
     app.kubernetes.io/instance: example
     app.kubernetes.io/version: "0.160.0"

--- a/charts/opentelemetry-collector/examples/custom-metrics-hpa/rendered/service.yaml
+++ b/charts/opentelemetry-collector/examples/custom-metrics-hpa/rendered/service.yaml
@@ -6,7 +6,7 @@ metadata:
   name: example-opentelemetry-collector
   namespace: default
   labels:
-    helm.sh/chart: opentelemetry-collector-0.173.0
+    helm.sh/chart: opentelemetry-collector-0.173.1
     app.kubernetes.io/name: opentelemetry-collector
     app.kubernetes.io/instance: example
     app.kubernetes.io/version: "0.160.0"

--- a/charts/opentelemetry-collector/examples/custom-metrics-hpa/rendered/serviceaccount.yaml
+++ b/charts/opentelemetry-collector/examples/custom-metrics-hpa/rendered/serviceaccount.yaml
@@ -6,7 +6,7 @@ metadata:
   name: example-opentelemetry-collector
   namespace: default
   labels:
-    helm.sh/chart: opentelemetry-collector-0.173.0
+    helm.sh/chart: opentelemetry-collector-0.173.1
     app.kubernetes.io/name: opentelemetry-collector
     app.kubernetes.io/instance: example
     app.kubernetes.io/version: "0.160.0"

--- a/charts/opentelemetry-collector/examples/daemonset-and-deployment/rendered/configmap-agent.yaml
+++ b/charts/opentelemetry-collector/examples/daemonset-and-deployment/rendered/configmap-agent.yaml
@@ -6,7 +6,7 @@ metadata:
   name: example-opentelemetry-collector-agent
   namespace: default
   labels:
-    helm.sh/chart: opentelemetry-collector-0.173.0
+    helm.sh/chart: opentelemetry-collector-0.173.1
     app.kubernetes.io/name: opentelemetry-collector
     app.kubernetes.io/instance: example
     app.kubernetes.io/version: "0.160.0"

--- a/charts/opentelemetry-collector/examples/daemonset-and-deployment/rendered/configmap.yaml
+++ b/charts/opentelemetry-collector/examples/daemonset-and-deployment/rendered/configmap.yaml
@@ -6,7 +6,7 @@ metadata:
   name: example-opentelemetry-collector
   namespace: default
   labels:
-    helm.sh/chart: opentelemetry-collector-0.173.0
+    helm.sh/chart: opentelemetry-collector-0.173.1
     app.kubernetes.io/name: opentelemetry-collector
     app.kubernetes.io/instance: example
     app.kubernetes.io/version: "0.160.0"

--- a/charts/opentelemetry-collector/examples/daemonset-and-deployment/rendered/daemonset.yaml
+++ b/charts/opentelemetry-collector/examples/daemonset-and-deployment/rendered/daemonset.yaml
@@ -6,7 +6,7 @@ metadata:
   name: example-opentelemetry-collector-agent
   namespace: default
   labels:
-    helm.sh/chart: opentelemetry-collector-0.173.0
+    helm.sh/chart: opentelemetry-collector-0.173.1
     app.kubernetes.io/name: opentelemetry-collector
     app.kubernetes.io/instance: example
     app.kubernetes.io/version: "0.160.0"
@@ -25,7 +25,7 @@ spec:
   template:
     metadata:
       annotations:
-        checksum/config: 4dc7a14f579eb0804ea0c9c8c31fecca63eeaacd38ce8c2135acebde7b3d1cde
+        checksum/config: 14712b60794517230bd11bc84320746ba4d9fabdccd7a633be1595f7d3be91f9
         
       labels:
         app.kubernetes.io/name: opentelemetry-collector

--- a/charts/opentelemetry-collector/examples/daemonset-and-deployment/rendered/deployment.yaml
+++ b/charts/opentelemetry-collector/examples/daemonset-and-deployment/rendered/deployment.yaml
@@ -6,7 +6,7 @@ metadata:
   name: example-opentelemetry-collector
   namespace: default
   labels:
-    helm.sh/chart: opentelemetry-collector-0.173.0
+    helm.sh/chart: opentelemetry-collector-0.173.1
     app.kubernetes.io/name: opentelemetry-collector
     app.kubernetes.io/instance: example
     app.kubernetes.io/version: "0.160.0"
@@ -26,7 +26,7 @@ spec:
   template:
     metadata:
       annotations:
-        checksum/config: 7c0bf33c0be34f870c3af2532a360fc9844bd75080b6f0e08f52e971ed6b50a3
+        checksum/config: e4ff59dfcded1b562c6b8ef93fad7a7c6954b8d279b8599f87252ae1caa773e2
         
       labels:
         app.kubernetes.io/name: opentelemetry-collector

--- a/charts/opentelemetry-collector/examples/daemonset-and-deployment/rendered/service.yaml
+++ b/charts/opentelemetry-collector/examples/daemonset-and-deployment/rendered/service.yaml
@@ -6,7 +6,7 @@ metadata:
   name: example-opentelemetry-collector
   namespace: default
   labels:
-    helm.sh/chart: opentelemetry-collector-0.173.0
+    helm.sh/chart: opentelemetry-collector-0.173.1
     app.kubernetes.io/name: opentelemetry-collector
     app.kubernetes.io/instance: example
     app.kubernetes.io/version: "0.160.0"

--- a/charts/opentelemetry-collector/examples/daemonset-and-deployment/rendered/serviceaccount.yaml
+++ b/charts/opentelemetry-collector/examples/daemonset-and-deployment/rendered/serviceaccount.yaml
@@ -6,7 +6,7 @@ metadata:
   name: example-opentelemetry-collector
   namespace: default
   labels:
-    helm.sh/chart: opentelemetry-collector-0.173.0
+    helm.sh/chart: opentelemetry-collector-0.173.1
     app.kubernetes.io/name: opentelemetry-collector
     app.kubernetes.io/instance: example
     app.kubernetes.io/version: "0.160.0"

--- a/charts/opentelemetry-collector/examples/daemonset-annotation-discovery/rendered/clusterrole.yaml
+++ b/charts/opentelemetry-collector/examples/daemonset-annotation-discovery/rendered/clusterrole.yaml
@@ -5,7 +5,7 @@ kind: ClusterRole
 metadata:
   name: example-opentelemetry-collector
   labels:
-    helm.sh/chart: opentelemetry-collector-0.173.0
+    helm.sh/chart: opentelemetry-collector-0.173.1
     app.kubernetes.io/name: opentelemetry-collector
     app.kubernetes.io/instance: example
     app.kubernetes.io/version: "0.160.0"

--- a/charts/opentelemetry-collector/examples/daemonset-annotation-discovery/rendered/clusterrolebinding.yaml
+++ b/charts/opentelemetry-collector/examples/daemonset-annotation-discovery/rendered/clusterrolebinding.yaml
@@ -5,7 +5,7 @@ kind: ClusterRoleBinding
 metadata:
   name: example-opentelemetry-collector
   labels:
-    helm.sh/chart: opentelemetry-collector-0.173.0
+    helm.sh/chart: opentelemetry-collector-0.173.1
     app.kubernetes.io/name: opentelemetry-collector
     app.kubernetes.io/instance: example
     app.kubernetes.io/version: "0.160.0"

--- a/charts/opentelemetry-collector/examples/daemonset-annotation-discovery/rendered/configmap-agent.yaml
+++ b/charts/opentelemetry-collector/examples/daemonset-annotation-discovery/rendered/configmap-agent.yaml
@@ -6,7 +6,7 @@ metadata:
   name: example-opentelemetry-collector-agent
   namespace: default
   labels:
-    helm.sh/chart: opentelemetry-collector-0.173.0
+    helm.sh/chart: opentelemetry-collector-0.173.1
     app.kubernetes.io/name: opentelemetry-collector
     app.kubernetes.io/instance: example
     app.kubernetes.io/version: "0.160.0"

--- a/charts/opentelemetry-collector/examples/daemonset-annotation-discovery/rendered/daemonset.yaml
+++ b/charts/opentelemetry-collector/examples/daemonset-annotation-discovery/rendered/daemonset.yaml
@@ -6,7 +6,7 @@ metadata:
   name: example-opentelemetry-collector-agent
   namespace: default
   labels:
-    helm.sh/chart: opentelemetry-collector-0.173.0
+    helm.sh/chart: opentelemetry-collector-0.173.1
     app.kubernetes.io/name: opentelemetry-collector
     app.kubernetes.io/instance: example
     app.kubernetes.io/version: "0.160.0"
@@ -25,7 +25,7 @@ spec:
   template:
     metadata:
       annotations:
-        checksum/config: 3b403aeaa71de99f360555defbe4851f56ede57d4ac43af4565e4204a2956368
+        checksum/config: 94d4bb4d95ce8cc58593036006c980ffecf8991b599ecbae8ccb8abbfc3e03b4
         io.opentelemetry.discovery.logs/enabled: "false"
       labels:
         app.kubernetes.io/name: opentelemetry-collector

--- a/charts/opentelemetry-collector/examples/daemonset-annotation-discovery/rendered/serviceaccount.yaml
+++ b/charts/opentelemetry-collector/examples/daemonset-annotation-discovery/rendered/serviceaccount.yaml
@@ -6,7 +6,7 @@ metadata:
   name: example-opentelemetry-collector
   namespace: default
   labels:
-    helm.sh/chart: opentelemetry-collector-0.173.0
+    helm.sh/chart: opentelemetry-collector-0.173.1
     app.kubernetes.io/name: opentelemetry-collector
     app.kubernetes.io/instance: example
     app.kubernetes.io/version: "0.160.0"

--- a/charts/opentelemetry-collector/examples/daemonset-cluster-metrics/rendered/clusterrole.yaml
+++ b/charts/opentelemetry-collector/examples/daemonset-cluster-metrics/rendered/clusterrole.yaml
@@ -5,7 +5,7 @@ kind: ClusterRole
 metadata:
   name: example-opentelemetry-collector
   labels:
-    helm.sh/chart: opentelemetry-collector-0.173.0
+    helm.sh/chart: opentelemetry-collector-0.173.1
     app.kubernetes.io/name: opentelemetry-collector
     app.kubernetes.io/instance: example
     app.kubernetes.io/version: "0.160.0"

--- a/charts/opentelemetry-collector/examples/daemonset-cluster-metrics/rendered/clusterrolebinding.yaml
+++ b/charts/opentelemetry-collector/examples/daemonset-cluster-metrics/rendered/clusterrolebinding.yaml
@@ -5,7 +5,7 @@ kind: ClusterRoleBinding
 metadata:
   name: example-opentelemetry-collector
   labels:
-    helm.sh/chart: opentelemetry-collector-0.173.0
+    helm.sh/chart: opentelemetry-collector-0.173.1
     app.kubernetes.io/name: opentelemetry-collector
     app.kubernetes.io/instance: example
     app.kubernetes.io/version: "0.160.0"

--- a/charts/opentelemetry-collector/examples/daemonset-cluster-metrics/rendered/configmap-agent.yaml
+++ b/charts/opentelemetry-collector/examples/daemonset-cluster-metrics/rendered/configmap-agent.yaml
@@ -6,7 +6,7 @@ metadata:
   name: example-opentelemetry-collector-agent
   namespace: default
   labels:
-    helm.sh/chart: opentelemetry-collector-0.173.0
+    helm.sh/chart: opentelemetry-collector-0.173.1
     app.kubernetes.io/name: opentelemetry-collector
     app.kubernetes.io/instance: example
     app.kubernetes.io/version: "0.160.0"

--- a/charts/opentelemetry-collector/examples/daemonset-cluster-metrics/rendered/daemonset.yaml
+++ b/charts/opentelemetry-collector/examples/daemonset-cluster-metrics/rendered/daemonset.yaml
@@ -6,7 +6,7 @@ metadata:
   name: example-opentelemetry-collector-agent
   namespace: default
   labels:
-    helm.sh/chart: opentelemetry-collector-0.173.0
+    helm.sh/chart: opentelemetry-collector-0.173.1
     app.kubernetes.io/name: opentelemetry-collector
     app.kubernetes.io/instance: example
     app.kubernetes.io/version: "0.160.0"
@@ -25,7 +25,7 @@ spec:
   template:
     metadata:
       annotations:
-        checksum/config: c33132ab03a69508da8aec6bb0a5698d1103b2a86400c8c0ac552aadfc645579
+        checksum/config: 87368cda20bb8a284e978ae462d032d7492e3bea6e05b9db66d9e92fc5f42292
         
       labels:
         app.kubernetes.io/name: opentelemetry-collector

--- a/charts/opentelemetry-collector/examples/daemonset-cluster-metrics/rendered/serviceaccount.yaml
+++ b/charts/opentelemetry-collector/examples/daemonset-cluster-metrics/rendered/serviceaccount.yaml
@@ -6,7 +6,7 @@ metadata:
   name: example-opentelemetry-collector
   namespace: default
   labels:
-    helm.sh/chart: opentelemetry-collector-0.173.0
+    helm.sh/chart: opentelemetry-collector-0.173.1
     app.kubernetes.io/name: opentelemetry-collector
     app.kubernetes.io/instance: example
     app.kubernetes.io/version: "0.160.0"

--- a/charts/opentelemetry-collector/examples/daemonset-collector-logs/rendered/configmap-agent.yaml
+++ b/charts/opentelemetry-collector/examples/daemonset-collector-logs/rendered/configmap-agent.yaml
@@ -6,7 +6,7 @@ metadata:
   name: example-opentelemetry-collector-agent
   namespace: default
   labels:
-    helm.sh/chart: opentelemetry-collector-0.173.0
+    helm.sh/chart: opentelemetry-collector-0.173.1
     app.kubernetes.io/name: opentelemetry-collector
     app.kubernetes.io/instance: example
     app.kubernetes.io/version: "0.160.0"

--- a/charts/opentelemetry-collector/examples/daemonset-collector-logs/rendered/daemonset.yaml
+++ b/charts/opentelemetry-collector/examples/daemonset-collector-logs/rendered/daemonset.yaml
@@ -6,7 +6,7 @@ metadata:
   name: example-opentelemetry-collector-agent
   namespace: default
   labels:
-    helm.sh/chart: opentelemetry-collector-0.173.0
+    helm.sh/chart: opentelemetry-collector-0.173.1
     app.kubernetes.io/name: opentelemetry-collector
     app.kubernetes.io/instance: example
     app.kubernetes.io/version: "0.160.0"
@@ -25,7 +25,7 @@ spec:
   template:
     metadata:
       annotations:
-        checksum/config: 2d8df36758ca2bedc2fed611450180d4bf135ecf6f0ed5f681fcf5f3340ef7a6
+        checksum/config: b97232849d447fdfb61ad636fcc4bbe29970217f4b5c6181c180aa781a9a3fca
         
       labels:
         app.kubernetes.io/name: opentelemetry-collector

--- a/charts/opentelemetry-collector/examples/daemonset-collector-logs/rendered/serviceaccount.yaml
+++ b/charts/opentelemetry-collector/examples/daemonset-collector-logs/rendered/serviceaccount.yaml
@@ -6,7 +6,7 @@ metadata:
   name: example-opentelemetry-collector
   namespace: default
   labels:
-    helm.sh/chart: opentelemetry-collector-0.173.0
+    helm.sh/chart: opentelemetry-collector-0.173.1
     app.kubernetes.io/name: opentelemetry-collector
     app.kubernetes.io/instance: example
     app.kubernetes.io/version: "0.160.0"

--- a/charts/opentelemetry-collector/examples/daemonset-hostmetrics/rendered/configmap-agent.yaml
+++ b/charts/opentelemetry-collector/examples/daemonset-hostmetrics/rendered/configmap-agent.yaml
@@ -6,7 +6,7 @@ metadata:
   name: example-opentelemetry-collector-agent
   namespace: default
   labels:
-    helm.sh/chart: opentelemetry-collector-0.173.0
+    helm.sh/chart: opentelemetry-collector-0.173.1
     app.kubernetes.io/name: opentelemetry-collector
     app.kubernetes.io/instance: example
     app.kubernetes.io/version: "0.160.0"

--- a/charts/opentelemetry-collector/examples/daemonset-hostmetrics/rendered/daemonset.yaml
+++ b/charts/opentelemetry-collector/examples/daemonset-hostmetrics/rendered/daemonset.yaml
@@ -6,7 +6,7 @@ metadata:
   name: example-opentelemetry-collector-agent
   namespace: default
   labels:
-    helm.sh/chart: opentelemetry-collector-0.173.0
+    helm.sh/chart: opentelemetry-collector-0.173.1
     app.kubernetes.io/name: opentelemetry-collector
     app.kubernetes.io/instance: example
     app.kubernetes.io/version: "0.160.0"
@@ -25,7 +25,7 @@ spec:
   template:
     metadata:
       annotations:
-        checksum/config: 40182496234879c3a583eaf0183972ea13797f390aec5a19a299d9d451d6559f
+        checksum/config: 7be2417925a41206f8a58b324da01faf0a36931c94570cd907958ef4ac191e63
         
       labels:
         app.kubernetes.io/name: opentelemetry-collector

--- a/charts/opentelemetry-collector/examples/daemonset-hostmetrics/rendered/serviceaccount.yaml
+++ b/charts/opentelemetry-collector/examples/daemonset-hostmetrics/rendered/serviceaccount.yaml
@@ -6,7 +6,7 @@ metadata:
   name: example-opentelemetry-collector
   namespace: default
   labels:
-    helm.sh/chart: opentelemetry-collector-0.173.0
+    helm.sh/chart: opentelemetry-collector-0.173.1
     app.kubernetes.io/name: opentelemetry-collector
     app.kubernetes.io/instance: example
     app.kubernetes.io/version: "0.160.0"

--- a/charts/opentelemetry-collector/examples/daemonset-kubernetes-objects/rendered/clusterrole.yaml
+++ b/charts/opentelemetry-collector/examples/daemonset-kubernetes-objects/rendered/clusterrole.yaml
@@ -5,7 +5,7 @@ kind: ClusterRole
 metadata:
   name: example-opentelemetry-collector
   labels:
-    helm.sh/chart: opentelemetry-collector-0.173.0
+    helm.sh/chart: opentelemetry-collector-0.173.1
     app.kubernetes.io/name: opentelemetry-collector
     app.kubernetes.io/instance: example
     app.kubernetes.io/version: "0.160.0"

--- a/charts/opentelemetry-collector/examples/daemonset-kubernetes-objects/rendered/clusterrolebinding.yaml
+++ b/charts/opentelemetry-collector/examples/daemonset-kubernetes-objects/rendered/clusterrolebinding.yaml
@@ -5,7 +5,7 @@ kind: ClusterRoleBinding
 metadata:
   name: example-opentelemetry-collector
   labels:
-    helm.sh/chart: opentelemetry-collector-0.173.0
+    helm.sh/chart: opentelemetry-collector-0.173.1
     app.kubernetes.io/name: opentelemetry-collector
     app.kubernetes.io/instance: example
     app.kubernetes.io/version: "0.160.0"

--- a/charts/opentelemetry-collector/examples/daemonset-kubernetes-objects/rendered/configmap-agent.yaml
+++ b/charts/opentelemetry-collector/examples/daemonset-kubernetes-objects/rendered/configmap-agent.yaml
@@ -6,7 +6,7 @@ metadata:
   name: example-opentelemetry-collector-agent
   namespace: default
   labels:
-    helm.sh/chart: opentelemetry-collector-0.173.0
+    helm.sh/chart: opentelemetry-collector-0.173.1
     app.kubernetes.io/name: opentelemetry-collector
     app.kubernetes.io/instance: example
     app.kubernetes.io/version: "0.160.0"

--- a/charts/opentelemetry-collector/examples/daemonset-kubernetes-objects/rendered/daemonset.yaml
+++ b/charts/opentelemetry-collector/examples/daemonset-kubernetes-objects/rendered/daemonset.yaml
@@ -6,7 +6,7 @@ metadata:
   name: example-opentelemetry-collector-agent
   namespace: default
   labels:
-    helm.sh/chart: opentelemetry-collector-0.173.0
+    helm.sh/chart: opentelemetry-collector-0.173.1
     app.kubernetes.io/name: opentelemetry-collector
     app.kubernetes.io/instance: example
     app.kubernetes.io/version: "0.160.0"
@@ -25,7 +25,7 @@ spec:
   template:
     metadata:
       annotations:
-        checksum/config: 2c70879b4e3466c8a195b27f7e74a542108c77abcec7b3a5cd70c1eab1883d0e
+        checksum/config: 0e820ce04f74e35a9f446f4f76fc98f899556c017cc837ada01a965ca62deaab
         
       labels:
         app.kubernetes.io/name: opentelemetry-collector

--- a/charts/opentelemetry-collector/examples/daemonset-kubernetes-objects/rendered/serviceaccount.yaml
+++ b/charts/opentelemetry-collector/examples/daemonset-kubernetes-objects/rendered/serviceaccount.yaml
@@ -6,7 +6,7 @@ metadata:
   name: example-opentelemetry-collector
   namespace: default
   labels:
-    helm.sh/chart: opentelemetry-collector-0.173.0
+    helm.sh/chart: opentelemetry-collector-0.173.1
     app.kubernetes.io/name: opentelemetry-collector
     app.kubernetes.io/instance: example
     app.kubernetes.io/version: "0.160.0"

--- a/charts/opentelemetry-collector/examples/daemonset-lifecycle-hooks/rendered/configmap-agent.yaml
+++ b/charts/opentelemetry-collector/examples/daemonset-lifecycle-hooks/rendered/configmap-agent.yaml
@@ -6,7 +6,7 @@ metadata:
   name: example-opentelemetry-collector-agent
   namespace: default
   labels:
-    helm.sh/chart: opentelemetry-collector-0.173.0
+    helm.sh/chart: opentelemetry-collector-0.173.1
     app.kubernetes.io/name: opentelemetry-collector
     app.kubernetes.io/instance: example
     app.kubernetes.io/version: "0.160.0"

--- a/charts/opentelemetry-collector/examples/daemonset-lifecycle-hooks/rendered/daemonset.yaml
+++ b/charts/opentelemetry-collector/examples/daemonset-lifecycle-hooks/rendered/daemonset.yaml
@@ -6,7 +6,7 @@ metadata:
   name: example-opentelemetry-collector-agent
   namespace: default
   labels:
-    helm.sh/chart: opentelemetry-collector-0.173.0
+    helm.sh/chart: opentelemetry-collector-0.173.1
     app.kubernetes.io/name: opentelemetry-collector
     app.kubernetes.io/instance: example
     app.kubernetes.io/version: "0.160.0"
@@ -25,7 +25,7 @@ spec:
   template:
     metadata:
       annotations:
-        checksum/config: a3d455f702bef6801c2a27243a5dba5d17a3ed8c464bf17e67c3659a4522fb3f
+        checksum/config: e4ff59dfcded1b562c6b8ef93fad7a7c6954b8d279b8599f87252ae1caa773e2
         
       labels:
         app.kubernetes.io/name: opentelemetry-collector

--- a/charts/opentelemetry-collector/examples/daemonset-lifecycle-hooks/rendered/serviceaccount.yaml
+++ b/charts/opentelemetry-collector/examples/daemonset-lifecycle-hooks/rendered/serviceaccount.yaml
@@ -6,7 +6,7 @@ metadata:
   name: example-opentelemetry-collector
   namespace: default
   labels:
-    helm.sh/chart: opentelemetry-collector-0.173.0
+    helm.sh/chart: opentelemetry-collector-0.173.1
     app.kubernetes.io/name: opentelemetry-collector
     app.kubernetes.io/instance: example
     app.kubernetes.io/version: "0.160.0"

--- a/charts/opentelemetry-collector/examples/daemonset-only/rendered/configmap-agent.yaml
+++ b/charts/opentelemetry-collector/examples/daemonset-only/rendered/configmap-agent.yaml
@@ -6,7 +6,7 @@ metadata:
   name: example-opentelemetry-collector-agent
   namespace: default
   labels:
-    helm.sh/chart: opentelemetry-collector-0.173.0
+    helm.sh/chart: opentelemetry-collector-0.173.1
     app.kubernetes.io/name: opentelemetry-collector
     app.kubernetes.io/instance: example
     app.kubernetes.io/version: "0.160.0"

--- a/charts/opentelemetry-collector/examples/daemonset-only/rendered/daemonset.yaml
+++ b/charts/opentelemetry-collector/examples/daemonset-only/rendered/daemonset.yaml
@@ -6,7 +6,7 @@ metadata:
   name: example-opentelemetry-collector-agent
   namespace: default
   labels:
-    helm.sh/chart: opentelemetry-collector-0.173.0
+    helm.sh/chart: opentelemetry-collector-0.173.1
     app.kubernetes.io/name: opentelemetry-collector
     app.kubernetes.io/instance: example
     app.kubernetes.io/version: "0.160.0"
@@ -25,7 +25,7 @@ spec:
   template:
     metadata:
       annotations:
-        checksum/config: a3d455f702bef6801c2a27243a5dba5d17a3ed8c464bf17e67c3659a4522fb3f
+        checksum/config: e4ff59dfcded1b562c6b8ef93fad7a7c6954b8d279b8599f87252ae1caa773e2
         
       labels:
         app.kubernetes.io/name: opentelemetry-collector

--- a/charts/opentelemetry-collector/examples/daemonset-only/rendered/serviceaccount.yaml
+++ b/charts/opentelemetry-collector/examples/daemonset-only/rendered/serviceaccount.yaml
@@ -6,7 +6,7 @@ metadata:
   name: example-opentelemetry-collector
   namespace: default
   labels:
-    helm.sh/chart: opentelemetry-collector-0.173.0
+    helm.sh/chart: opentelemetry-collector-0.173.1
     app.kubernetes.io/name: opentelemetry-collector
     app.kubernetes.io/instance: example
     app.kubernetes.io/version: "0.160.0"

--- a/charts/opentelemetry-collector/examples/daemonset-resource-detection/rendered/clusterrole.yaml
+++ b/charts/opentelemetry-collector/examples/daemonset-resource-detection/rendered/clusterrole.yaml
@@ -5,7 +5,7 @@ kind: ClusterRole
 metadata:
   name: example-opentelemetry-collector
   labels:
-    helm.sh/chart: opentelemetry-collector-0.173.0
+    helm.sh/chart: opentelemetry-collector-0.173.1
     app.kubernetes.io/name: opentelemetry-collector
     app.kubernetes.io/instance: example
     app.kubernetes.io/version: "0.160.0"

--- a/charts/opentelemetry-collector/examples/daemonset-resource-detection/rendered/clusterrolebinding.yaml
+++ b/charts/opentelemetry-collector/examples/daemonset-resource-detection/rendered/clusterrolebinding.yaml
@@ -5,7 +5,7 @@ kind: ClusterRoleBinding
 metadata:
   name: example-opentelemetry-collector
   labels:
-    helm.sh/chart: opentelemetry-collector-0.173.0
+    helm.sh/chart: opentelemetry-collector-0.173.1
     app.kubernetes.io/name: opentelemetry-collector
     app.kubernetes.io/instance: example
     app.kubernetes.io/version: "0.160.0"

--- a/charts/opentelemetry-collector/examples/daemonset-resource-detection/rendered/configmap-agent.yaml
+++ b/charts/opentelemetry-collector/examples/daemonset-resource-detection/rendered/configmap-agent.yaml
@@ -6,7 +6,7 @@ metadata:
   name: example-opentelemetry-collector-agent
   namespace: default
   labels:
-    helm.sh/chart: opentelemetry-collector-0.173.0
+    helm.sh/chart: opentelemetry-collector-0.173.1
     app.kubernetes.io/name: opentelemetry-collector
     app.kubernetes.io/instance: example
     app.kubernetes.io/version: "0.160.0"

--- a/charts/opentelemetry-collector/examples/daemonset-resource-detection/rendered/daemonset.yaml
+++ b/charts/opentelemetry-collector/examples/daemonset-resource-detection/rendered/daemonset.yaml
@@ -6,7 +6,7 @@ metadata:
   name: example-opentelemetry-collector-agent
   namespace: default
   labels:
-    helm.sh/chart: opentelemetry-collector-0.173.0
+    helm.sh/chart: opentelemetry-collector-0.173.1
     app.kubernetes.io/name: opentelemetry-collector
     app.kubernetes.io/instance: example
     app.kubernetes.io/version: "0.160.0"
@@ -25,7 +25,7 @@ spec:
   template:
     metadata:
       annotations:
-        checksum/config: 8eb38e5a7c1b42ab922387056d86e527bba2011d53020eeadd6d6af4d1198775
+        checksum/config: 1e60121fcc2d562f1225e22874e6aeb1d60a4332926f18913245208fe402d0ca
         
       labels:
         app.kubernetes.io/name: opentelemetry-collector

--- a/charts/opentelemetry-collector/examples/daemonset-resource-detection/rendered/serviceaccount.yaml
+++ b/charts/opentelemetry-collector/examples/daemonset-resource-detection/rendered/serviceaccount.yaml
@@ -6,7 +6,7 @@ metadata:
   name: example-opentelemetry-collector
   namespace: default
   labels:
-    helm.sh/chart: opentelemetry-collector-0.173.0
+    helm.sh/chart: opentelemetry-collector-0.173.1
     app.kubernetes.io/name: opentelemetry-collector
     app.kubernetes.io/instance: example
     app.kubernetes.io/version: "0.160.0"

--- a/charts/opentelemetry-collector/examples/deployment-cluster-metrics/rendered/clusterrole.yaml
+++ b/charts/opentelemetry-collector/examples/deployment-cluster-metrics/rendered/clusterrole.yaml
@@ -5,7 +5,7 @@ kind: ClusterRole
 metadata:
   name: example-opentelemetry-collector
   labels:
-    helm.sh/chart: opentelemetry-collector-0.173.0
+    helm.sh/chart: opentelemetry-collector-0.173.1
     app.kubernetes.io/name: opentelemetry-collector
     app.kubernetes.io/instance: example
     app.kubernetes.io/version: "0.160.0"

--- a/charts/opentelemetry-collector/examples/deployment-cluster-metrics/rendered/clusterrolebinding.yaml
+++ b/charts/opentelemetry-collector/examples/deployment-cluster-metrics/rendered/clusterrolebinding.yaml
@@ -5,7 +5,7 @@ kind: ClusterRoleBinding
 metadata:
   name: example-opentelemetry-collector
   labels:
-    helm.sh/chart: opentelemetry-collector-0.173.0
+    helm.sh/chart: opentelemetry-collector-0.173.1
     app.kubernetes.io/name: opentelemetry-collector
     app.kubernetes.io/instance: example
     app.kubernetes.io/version: "0.160.0"

--- a/charts/opentelemetry-collector/examples/deployment-cluster-metrics/rendered/configmap.yaml
+++ b/charts/opentelemetry-collector/examples/deployment-cluster-metrics/rendered/configmap.yaml
@@ -6,7 +6,7 @@ metadata:
   name: example-opentelemetry-collector
   namespace: default
   labels:
-    helm.sh/chart: opentelemetry-collector-0.173.0
+    helm.sh/chart: opentelemetry-collector-0.173.1
     app.kubernetes.io/name: opentelemetry-collector
     app.kubernetes.io/instance: example
     app.kubernetes.io/version: "0.160.0"

--- a/charts/opentelemetry-collector/examples/deployment-cluster-metrics/rendered/deployment.yaml
+++ b/charts/opentelemetry-collector/examples/deployment-cluster-metrics/rendered/deployment.yaml
@@ -6,7 +6,7 @@ metadata:
   name: example-opentelemetry-collector
   namespace: default
   labels:
-    helm.sh/chart: opentelemetry-collector-0.173.0
+    helm.sh/chart: opentelemetry-collector-0.173.1
     app.kubernetes.io/name: opentelemetry-collector
     app.kubernetes.io/instance: example
     app.kubernetes.io/version: "0.160.0"
@@ -26,7 +26,7 @@ spec:
   template:
     metadata:
       annotations:
-        checksum/config: 669488633614d1a3de185b170fe4ca6c7f6bba91e377cf7abf93fa7131e8871d
+        checksum/config: 28aacff054752f07c5218443ce80c6d1a07c8aa650e5cfb892f696e9f6da3e15
         
       labels:
         app.kubernetes.io/name: opentelemetry-collector

--- a/charts/opentelemetry-collector/examples/deployment-cluster-metrics/rendered/service.yaml
+++ b/charts/opentelemetry-collector/examples/deployment-cluster-metrics/rendered/service.yaml
@@ -6,7 +6,7 @@ metadata:
   name: example-opentelemetry-collector
   namespace: default
   labels:
-    helm.sh/chart: opentelemetry-collector-0.173.0
+    helm.sh/chart: opentelemetry-collector-0.173.1
     app.kubernetes.io/name: opentelemetry-collector
     app.kubernetes.io/instance: example
     app.kubernetes.io/version: "0.160.0"

--- a/charts/opentelemetry-collector/examples/deployment-cluster-metrics/rendered/serviceaccount.yaml
+++ b/charts/opentelemetry-collector/examples/deployment-cluster-metrics/rendered/serviceaccount.yaml
@@ -6,7 +6,7 @@ metadata:
   name: example-opentelemetry-collector
   namespace: default
   labels:
-    helm.sh/chart: opentelemetry-collector-0.173.0
+    helm.sh/chart: opentelemetry-collector-0.173.1
     app.kubernetes.io/name: opentelemetry-collector
     app.kubernetes.io/instance: example
     app.kubernetes.io/version: "0.160.0"

--- a/charts/opentelemetry-collector/examples/deployment-only/rendered/configmap.yaml
+++ b/charts/opentelemetry-collector/examples/deployment-only/rendered/configmap.yaml
@@ -6,7 +6,7 @@ metadata:
   name: example-opentelemetry-collector
   namespace: default
   labels:
-    helm.sh/chart: opentelemetry-collector-0.173.0
+    helm.sh/chart: opentelemetry-collector-0.173.1
     app.kubernetes.io/name: opentelemetry-collector
     app.kubernetes.io/instance: example
     app.kubernetes.io/version: "0.160.0"

--- a/charts/opentelemetry-collector/examples/deployment-only/rendered/deployment.yaml
+++ b/charts/opentelemetry-collector/examples/deployment-only/rendered/deployment.yaml
@@ -6,7 +6,7 @@ metadata:
   name: example-opentelemetry-collector
   namespace: default
   labels:
-    helm.sh/chart: opentelemetry-collector-0.173.0
+    helm.sh/chart: opentelemetry-collector-0.173.1
     app.kubernetes.io/name: opentelemetry-collector
     app.kubernetes.io/instance: example
     app.kubernetes.io/version: "0.160.0"
@@ -26,7 +26,7 @@ spec:
   template:
     metadata:
       annotations:
-        checksum/config: 7c0bf33c0be34f870c3af2532a360fc9844bd75080b6f0e08f52e971ed6b50a3
+        checksum/config: e4ff59dfcded1b562c6b8ef93fad7a7c6954b8d279b8599f87252ae1caa773e2
         
       labels:
         app.kubernetes.io/name: opentelemetry-collector

--- a/charts/opentelemetry-collector/examples/deployment-only/rendered/service.yaml
+++ b/charts/opentelemetry-collector/examples/deployment-only/rendered/service.yaml
@@ -6,7 +6,7 @@ metadata:
   name: example-opentelemetry-collector
   namespace: default
   labels:
-    helm.sh/chart: opentelemetry-collector-0.173.0
+    helm.sh/chart: opentelemetry-collector-0.173.1
     app.kubernetes.io/name: opentelemetry-collector
     app.kubernetes.io/instance: example
     app.kubernetes.io/version: "0.160.0"

--- a/charts/opentelemetry-collector/examples/deployment-only/rendered/serviceaccount.yaml
+++ b/charts/opentelemetry-collector/examples/deployment-only/rendered/serviceaccount.yaml
@@ -6,7 +6,7 @@ metadata:
   name: example-opentelemetry-collector
   namespace: default
   labels:
-    helm.sh/chart: opentelemetry-collector-0.173.0
+    helm.sh/chart: opentelemetry-collector-0.173.1
     app.kubernetes.io/name: opentelemetry-collector
     app.kubernetes.io/instance: example
     app.kubernetes.io/version: "0.160.0"

--- a/charts/opentelemetry-collector/examples/deployment-otlp-traces/rendered/configmap.yaml
+++ b/charts/opentelemetry-collector/examples/deployment-otlp-traces/rendered/configmap.yaml
@@ -6,7 +6,7 @@ metadata:
   name: example-opentelemetry-collector
   namespace: default
   labels:
-    helm.sh/chart: opentelemetry-collector-0.173.0
+    helm.sh/chart: opentelemetry-collector-0.173.1
     app.kubernetes.io/name: opentelemetry-collector
     app.kubernetes.io/instance: example
     app.kubernetes.io/version: "0.160.0"

--- a/charts/opentelemetry-collector/examples/deployment-otlp-traces/rendered/deployment.yaml
+++ b/charts/opentelemetry-collector/examples/deployment-otlp-traces/rendered/deployment.yaml
@@ -6,7 +6,7 @@ metadata:
   name: example-opentelemetry-collector
   namespace: default
   labels:
-    helm.sh/chart: opentelemetry-collector-0.173.0
+    helm.sh/chart: opentelemetry-collector-0.173.1
     app.kubernetes.io/name: opentelemetry-collector
     app.kubernetes.io/instance: example
     app.kubernetes.io/version: "0.160.0"
@@ -26,7 +26,7 @@ spec:
   template:
     metadata:
       annotations:
-        checksum/config: c5a0b1dc652c8f8eabae195b9d9d2eb0a06bcbb9989b780a8af1673f11c07168
+        checksum/config: b61dfdc48ad4295bfb58ce91d3abc86c2f1da0687a3dedfd747df52fd2f9e1fe
         
       labels:
         app.kubernetes.io/name: opentelemetry-collector

--- a/charts/opentelemetry-collector/examples/deployment-otlp-traces/rendered/service.yaml
+++ b/charts/opentelemetry-collector/examples/deployment-otlp-traces/rendered/service.yaml
@@ -6,7 +6,7 @@ metadata:
   name: example-opentelemetry-collector
   namespace: default
   labels:
-    helm.sh/chart: opentelemetry-collector-0.173.0
+    helm.sh/chart: opentelemetry-collector-0.173.1
     app.kubernetes.io/name: opentelemetry-collector
     app.kubernetes.io/instance: example
     app.kubernetes.io/version: "0.160.0"

--- a/charts/opentelemetry-collector/examples/deployment-otlp-traces/rendered/serviceaccount.yaml
+++ b/charts/opentelemetry-collector/examples/deployment-otlp-traces/rendered/serviceaccount.yaml
@@ -6,7 +6,7 @@ metadata:
   name: example-opentelemetry-collector
   namespace: default
   labels:
-    helm.sh/chart: opentelemetry-collector-0.173.0
+    helm.sh/chart: opentelemetry-collector-0.173.1
     app.kubernetes.io/name: opentelemetry-collector
     app.kubernetes.io/instance: example
     app.kubernetes.io/version: "0.160.0"

--- a/charts/opentelemetry-collector/examples/deployment-use-existing-configMap/rendered/deployment.yaml
+++ b/charts/opentelemetry-collector/examples/deployment-use-existing-configMap/rendered/deployment.yaml
@@ -6,7 +6,7 @@ metadata:
   name: example-opentelemetry-collector
   namespace: default
   labels:
-    helm.sh/chart: opentelemetry-collector-0.173.0
+    helm.sh/chart: opentelemetry-collector-0.173.1
     app.kubernetes.io/name: opentelemetry-collector
     app.kubernetes.io/instance: example
     app.kubernetes.io/version: "0.160.0"
@@ -26,7 +26,7 @@ spec:
   template:
     metadata:
       annotations:
-        checksum/config: 01ba4719c80b6fe911b091a7c05124b64eeece964e09c058ef8f9805daca546b
+        checksum/config: 44136fa355b3678a1146ad16f7e8649e94fb4fc21fe77e8310c060f61caaff8a
         
       labels:
         app.kubernetes.io/name: opentelemetry-collector

--- a/charts/opentelemetry-collector/examples/deployment-use-existing-configMap/rendered/service.yaml
+++ b/charts/opentelemetry-collector/examples/deployment-use-existing-configMap/rendered/service.yaml
@@ -6,7 +6,7 @@ metadata:
   name: example-opentelemetry-collector
   namespace: default
   labels:
-    helm.sh/chart: opentelemetry-collector-0.173.0
+    helm.sh/chart: opentelemetry-collector-0.173.1
     app.kubernetes.io/name: opentelemetry-collector
     app.kubernetes.io/instance: example
     app.kubernetes.io/version: "0.160.0"

--- a/charts/opentelemetry-collector/examples/deployment-use-existing-configMap/rendered/serviceaccount.yaml
+++ b/charts/opentelemetry-collector/examples/deployment-use-existing-configMap/rendered/serviceaccount.yaml
@@ -6,7 +6,7 @@ metadata:
   name: example-opentelemetry-collector
   namespace: default
   labels:
-    helm.sh/chart: opentelemetry-collector-0.173.0
+    helm.sh/chart: opentelemetry-collector-0.173.1
     app.kubernetes.io/name: opentelemetry-collector
     app.kubernetes.io/instance: example
     app.kubernetes.io/version: "0.160.0"

--- a/charts/opentelemetry-collector/examples/internalTelemetryViaOTLP/rendered/configmap.yaml
+++ b/charts/opentelemetry-collector/examples/internalTelemetryViaOTLP/rendered/configmap.yaml
@@ -6,7 +6,7 @@ metadata:
   name: example-opentelemetry-collector
   namespace: default
   labels:
-    helm.sh/chart: opentelemetry-collector-0.173.0
+    helm.sh/chart: opentelemetry-collector-0.173.1
     app.kubernetes.io/name: opentelemetry-collector
     app.kubernetes.io/instance: example
     app.kubernetes.io/version: "0.160.0"

--- a/charts/opentelemetry-collector/examples/internalTelemetryViaOTLP/rendered/deployment.yaml
+++ b/charts/opentelemetry-collector/examples/internalTelemetryViaOTLP/rendered/deployment.yaml
@@ -6,7 +6,7 @@ metadata:
   name: example-opentelemetry-collector
   namespace: default
   labels:
-    helm.sh/chart: opentelemetry-collector-0.173.0
+    helm.sh/chart: opentelemetry-collector-0.173.1
     app.kubernetes.io/name: opentelemetry-collector
     app.kubernetes.io/instance: example
     app.kubernetes.io/version: "0.160.0"
@@ -26,7 +26,7 @@ spec:
   template:
     metadata:
       annotations:
-        checksum/config: c7da1fb1de0e2e85a7ba0c18a80085fad4b36f5519a291956d77887c050b5450
+        checksum/config: c694f5cd3689ce699e3e6d4e06a989e660640816a196ea60d80f042068aa297b
         
       labels:
         app.kubernetes.io/name: opentelemetry-collector

--- a/charts/opentelemetry-collector/examples/internalTelemetryViaOTLP/rendered/service.yaml
+++ b/charts/opentelemetry-collector/examples/internalTelemetryViaOTLP/rendered/service.yaml
@@ -6,7 +6,7 @@ metadata:
   name: example-opentelemetry-collector
   namespace: default
   labels:
-    helm.sh/chart: opentelemetry-collector-0.173.0
+    helm.sh/chart: opentelemetry-collector-0.173.1
     app.kubernetes.io/name: opentelemetry-collector
     app.kubernetes.io/instance: example
     app.kubernetes.io/version: "0.160.0"

--- a/charts/opentelemetry-collector/examples/internalTelemetryViaOTLP/rendered/serviceaccount.yaml
+++ b/charts/opentelemetry-collector/examples/internalTelemetryViaOTLP/rendered/serviceaccount.yaml
@@ -6,7 +6,7 @@ metadata:
   name: example-opentelemetry-collector
   namespace: default
   labels:
-    helm.sh/chart: opentelemetry-collector-0.173.0
+    helm.sh/chart: opentelemetry-collector-0.173.1
     app.kubernetes.io/name: opentelemetry-collector
     app.kubernetes.io/instance: example
     app.kubernetes.io/version: "0.160.0"

--- a/charts/opentelemetry-collector/examples/kubernetesAttributes/rendered/clusterrole.yaml
+++ b/charts/opentelemetry-collector/examples/kubernetesAttributes/rendered/clusterrole.yaml
@@ -5,7 +5,7 @@ kind: ClusterRole
 metadata:
   name: example-opentelemetry-collector
   labels:
-    helm.sh/chart: opentelemetry-collector-0.173.0
+    helm.sh/chart: opentelemetry-collector-0.173.1
     app.kubernetes.io/name: opentelemetry-collector
     app.kubernetes.io/instance: example
     app.kubernetes.io/version: "0.160.0"

--- a/charts/opentelemetry-collector/examples/kubernetesAttributes/rendered/clusterrolebinding.yaml
+++ b/charts/opentelemetry-collector/examples/kubernetesAttributes/rendered/clusterrolebinding.yaml
@@ -5,7 +5,7 @@ kind: ClusterRoleBinding
 metadata:
   name: example-opentelemetry-collector
   labels:
-    helm.sh/chart: opentelemetry-collector-0.173.0
+    helm.sh/chart: opentelemetry-collector-0.173.1
     app.kubernetes.io/name: opentelemetry-collector
     app.kubernetes.io/instance: example
     app.kubernetes.io/version: "0.160.0"

--- a/charts/opentelemetry-collector/examples/kubernetesAttributes/rendered/configmap.yaml
+++ b/charts/opentelemetry-collector/examples/kubernetesAttributes/rendered/configmap.yaml
@@ -6,7 +6,7 @@ metadata:
   name: example-opentelemetry-collector
   namespace: default
   labels:
-    helm.sh/chart: opentelemetry-collector-0.173.0
+    helm.sh/chart: opentelemetry-collector-0.173.1
     app.kubernetes.io/name: opentelemetry-collector
     app.kubernetes.io/instance: example
     app.kubernetes.io/version: "0.160.0"

--- a/charts/opentelemetry-collector/examples/kubernetesAttributes/rendered/deployment.yaml
+++ b/charts/opentelemetry-collector/examples/kubernetesAttributes/rendered/deployment.yaml
@@ -6,7 +6,7 @@ metadata:
   name: example-opentelemetry-collector
   namespace: default
   labels:
-    helm.sh/chart: opentelemetry-collector-0.173.0
+    helm.sh/chart: opentelemetry-collector-0.173.1
     app.kubernetes.io/name: opentelemetry-collector
     app.kubernetes.io/instance: example
     app.kubernetes.io/version: "0.160.0"
@@ -26,7 +26,7 @@ spec:
   template:
     metadata:
       annotations:
-        checksum/config: cf3a3d28450d2a4c06ff3a25b83f5140ec16173f77c22e780c61d99a964f307c
+        checksum/config: 6eda722c90b658f28f679c9c118e8c39f2e041a5adf87a92e545f289e3f99621
         
       labels:
         app.kubernetes.io/name: opentelemetry-collector

--- a/charts/opentelemetry-collector/examples/kubernetesAttributes/rendered/service.yaml
+++ b/charts/opentelemetry-collector/examples/kubernetesAttributes/rendered/service.yaml
@@ -6,7 +6,7 @@ metadata:
   name: example-opentelemetry-collector
   namespace: default
   labels:
-    helm.sh/chart: opentelemetry-collector-0.173.0
+    helm.sh/chart: opentelemetry-collector-0.173.1
     app.kubernetes.io/name: opentelemetry-collector
     app.kubernetes.io/instance: example
     app.kubernetes.io/version: "0.160.0"

--- a/charts/opentelemetry-collector/examples/kubernetesAttributes/rendered/serviceaccount.yaml
+++ b/charts/opentelemetry-collector/examples/kubernetesAttributes/rendered/serviceaccount.yaml
@@ -6,7 +6,7 @@ metadata:
   name: example-opentelemetry-collector
   namespace: default
   labels:
-    helm.sh/chart: opentelemetry-collector-0.173.0
+    helm.sh/chart: opentelemetry-collector-0.173.1
     app.kubernetes.io/name: opentelemetry-collector
     app.kubernetes.io/instance: example
     app.kubernetes.io/version: "0.160.0"

--- a/charts/opentelemetry-collector/examples/statefulset-only/rendered/configmap-statefulset.yaml
+++ b/charts/opentelemetry-collector/examples/statefulset-only/rendered/configmap-statefulset.yaml
@@ -6,7 +6,7 @@ metadata:
   name: example-opentelemetry-collector-statefulset
   namespace: default
   labels:
-    helm.sh/chart: opentelemetry-collector-0.173.0
+    helm.sh/chart: opentelemetry-collector-0.173.1
     app.kubernetes.io/name: opentelemetry-collector
     app.kubernetes.io/instance: example
     app.kubernetes.io/version: "0.160.0"

--- a/charts/opentelemetry-collector/examples/statefulset-only/rendered/service.yaml
+++ b/charts/opentelemetry-collector/examples/statefulset-only/rendered/service.yaml
@@ -6,7 +6,7 @@ metadata:
   name: example-opentelemetry-collector
   namespace: default
   labels:
-    helm.sh/chart: opentelemetry-collector-0.173.0
+    helm.sh/chart: opentelemetry-collector-0.173.1
     app.kubernetes.io/name: opentelemetry-collector
     app.kubernetes.io/instance: example
     app.kubernetes.io/version: "0.160.0"

--- a/charts/opentelemetry-collector/examples/statefulset-only/rendered/serviceaccount.yaml
+++ b/charts/opentelemetry-collector/examples/statefulset-only/rendered/serviceaccount.yaml
@@ -6,7 +6,7 @@ metadata:
   name: example-opentelemetry-collector
   namespace: default
   labels:
-    helm.sh/chart: opentelemetry-collector-0.173.0
+    helm.sh/chart: opentelemetry-collector-0.173.1
     app.kubernetes.io/name: opentelemetry-collector
     app.kubernetes.io/instance: example
     app.kubernetes.io/version: "0.160.0"

--- a/charts/opentelemetry-collector/examples/statefulset-only/rendered/statefulset.yaml
+++ b/charts/opentelemetry-collector/examples/statefulset-only/rendered/statefulset.yaml
@@ -6,7 +6,7 @@ metadata:
   name: example-opentelemetry-collector
   namespace: default
   labels:
-    helm.sh/chart: opentelemetry-collector-0.173.0
+    helm.sh/chart: opentelemetry-collector-0.173.1
     app.kubernetes.io/name: opentelemetry-collector
     app.kubernetes.io/instance: example
     app.kubernetes.io/version: "0.160.0"
@@ -28,7 +28,7 @@ spec:
   template:
     metadata:
       annotations:
-        checksum/config: d41aa988157f2bdd3ae59b3dddce5b1f3704f2a1ca6400c2b16051d189fb5448
+        checksum/config: e4ff59dfcded1b562c6b8ef93fad7a7c6954b8d279b8599f87252ae1caa773e2
         
       labels:
         app.kubernetes.io/name: opentelemetry-collector

--- a/charts/opentelemetry-collector/examples/statefulset-with-pvc/rendered/configmap-statefulset.yaml
+++ b/charts/opentelemetry-collector/examples/statefulset-with-pvc/rendered/configmap-statefulset.yaml
@@ -6,7 +6,7 @@ metadata:
   name: example-opentelemetry-collector-statefulset
   namespace: default
   labels:
-    helm.sh/chart: opentelemetry-collector-0.173.0
+    helm.sh/chart: opentelemetry-collector-0.173.1
     app.kubernetes.io/name: opentelemetry-collector
     app.kubernetes.io/instance: example
     app.kubernetes.io/version: "0.160.0"

--- a/charts/opentelemetry-collector/examples/statefulset-with-pvc/rendered/service.yaml
+++ b/charts/opentelemetry-collector/examples/statefulset-with-pvc/rendered/service.yaml
@@ -6,7 +6,7 @@ metadata:
   name: example-opentelemetry-collector
   namespace: default
   labels:
-    helm.sh/chart: opentelemetry-collector-0.173.0
+    helm.sh/chart: opentelemetry-collector-0.173.1
     app.kubernetes.io/name: opentelemetry-collector
     app.kubernetes.io/instance: example
     app.kubernetes.io/version: "0.160.0"

--- a/charts/opentelemetry-collector/examples/statefulset-with-pvc/rendered/serviceaccount.yaml
+++ b/charts/opentelemetry-collector/examples/statefulset-with-pvc/rendered/serviceaccount.yaml
@@ -6,7 +6,7 @@ metadata:
   name: example-opentelemetry-collector
   namespace: default
   labels:
-    helm.sh/chart: opentelemetry-collector-0.173.0
+    helm.sh/chart: opentelemetry-collector-0.173.1
     app.kubernetes.io/name: opentelemetry-collector
     app.kubernetes.io/instance: example
     app.kubernetes.io/version: "0.160.0"

--- a/charts/opentelemetry-collector/examples/statefulset-with-pvc/rendered/statefulset.yaml
+++ b/charts/opentelemetry-collector/examples/statefulset-with-pvc/rendered/statefulset.yaml
@@ -6,7 +6,7 @@ metadata:
   name: example-opentelemetry-collector
   namespace: default
   labels:
-    helm.sh/chart: opentelemetry-collector-0.173.0
+    helm.sh/chart: opentelemetry-collector-0.173.1
     app.kubernetes.io/name: opentelemetry-collector
     app.kubernetes.io/instance: example
     app.kubernetes.io/version: "0.160.0"
@@ -31,7 +31,7 @@ spec:
   template:
     metadata:
       annotations:
-        checksum/config: d41aa988157f2bdd3ae59b3dddce5b1f3704f2a1ca6400c2b16051d189fb5448
+        checksum/config: e4ff59dfcded1b562c6b8ef93fad7a7c6954b8d279b8599f87252ae1caa773e2
         
       labels:
         app.kubernetes.io/name: opentelemetry-collector

--- a/charts/opentelemetry-collector/examples/using-GOMEMLIMIT/rendered/configmap.yaml
+++ b/charts/opentelemetry-collector/examples/using-GOMEMLIMIT/rendered/configmap.yaml
@@ -6,7 +6,7 @@ metadata:
   name: example-opentelemetry-collector
   namespace: default
   labels:
-    helm.sh/chart: opentelemetry-collector-0.173.0
+    helm.sh/chart: opentelemetry-collector-0.173.1
     app.kubernetes.io/name: opentelemetry-collector
     app.kubernetes.io/instance: example
     app.kubernetes.io/version: "0.160.0"

--- a/charts/opentelemetry-collector/examples/using-GOMEMLIMIT/rendered/deployment.yaml
+++ b/charts/opentelemetry-collector/examples/using-GOMEMLIMIT/rendered/deployment.yaml
@@ -6,7 +6,7 @@ metadata:
   name: example-opentelemetry-collector
   namespace: default
   labels:
-    helm.sh/chart: opentelemetry-collector-0.173.0
+    helm.sh/chart: opentelemetry-collector-0.173.1
     app.kubernetes.io/name: opentelemetry-collector
     app.kubernetes.io/instance: example
     app.kubernetes.io/version: "0.160.0"
@@ -26,7 +26,7 @@ spec:
   template:
     metadata:
       annotations:
-        checksum/config: 7c0bf33c0be34f870c3af2532a360fc9844bd75080b6f0e08f52e971ed6b50a3
+        checksum/config: e4ff59dfcded1b562c6b8ef93fad7a7c6954b8d279b8599f87252ae1caa773e2
         
       labels:
         app.kubernetes.io/name: opentelemetry-collector

--- a/charts/opentelemetry-collector/examples/using-GOMEMLIMIT/rendered/service.yaml
+++ b/charts/opentelemetry-collector/examples/using-GOMEMLIMIT/rendered/service.yaml
@@ -6,7 +6,7 @@ metadata:
   name: example-opentelemetry-collector
   namespace: default
   labels:
-    helm.sh/chart: opentelemetry-collector-0.173.0
+    helm.sh/chart: opentelemetry-collector-0.173.1
     app.kubernetes.io/name: opentelemetry-collector
     app.kubernetes.io/instance: example
     app.kubernetes.io/version: "0.160.0"

--- a/charts/opentelemetry-collector/examples/using-GOMEMLIMIT/rendered/serviceaccount.yaml
+++ b/charts/opentelemetry-collector/examples/using-GOMEMLIMIT/rendered/serviceaccount.yaml
@@ -6,7 +6,7 @@ metadata:
   name: example-opentelemetry-collector
   namespace: default
   labels:
-    helm.sh/chart: opentelemetry-collector-0.173.0
+    helm.sh/chart: opentelemetry-collector-0.173.1
     app.kubernetes.io/name: opentelemetry-collector
     app.kubernetes.io/instance: example
     app.kubernetes.io/version: "0.160.0"

--- a/charts/opentelemetry-collector/examples/using-custom-config/rendered/deployment.yaml
+++ b/charts/opentelemetry-collector/examples/using-custom-config/rendered/deployment.yaml
@@ -6,7 +6,7 @@ metadata:
   name: example-opentelemetry-collector
   namespace: default
   labels:
-    helm.sh/chart: opentelemetry-collector-0.173.0
+    helm.sh/chart: opentelemetry-collector-0.173.1
     app.kubernetes.io/name: opentelemetry-collector
     app.kubernetes.io/instance: example
     app.kubernetes.io/version: "0.160.0"
@@ -26,7 +26,7 @@ spec:
   template:
     metadata:
       annotations:
-        checksum/config: 01ba4719c80b6fe911b091a7c05124b64eeece964e09c058ef8f9805daca546b
+        checksum/config: 44136fa355b3678a1146ad16f7e8649e94fb4fc21fe77e8310c060f61caaff8a
         
       labels:
         app.kubernetes.io/name: opentelemetry-collector

--- a/charts/opentelemetry-collector/examples/using-custom-config/rendered/service.yaml
+++ b/charts/opentelemetry-collector/examples/using-custom-config/rendered/service.yaml
@@ -6,7 +6,7 @@ metadata:
   name: example-opentelemetry-collector
   namespace: default
   labels:
-    helm.sh/chart: opentelemetry-collector-0.173.0
+    helm.sh/chart: opentelemetry-collector-0.173.1
     app.kubernetes.io/name: opentelemetry-collector
     app.kubernetes.io/instance: example
     app.kubernetes.io/version: "0.160.0"

--- a/charts/opentelemetry-collector/examples/using-custom-config/rendered/serviceaccount.yaml
+++ b/charts/opentelemetry-collector/examples/using-custom-config/rendered/serviceaccount.yaml
@@ -6,7 +6,7 @@ metadata:
   name: example-opentelemetry-collector
   namespace: default
   labels:
-    helm.sh/chart: opentelemetry-collector-0.173.0
+    helm.sh/chart: opentelemetry-collector-0.173.1
     app.kubernetes.io/name: opentelemetry-collector
     app.kubernetes.io/instance: example
     app.kubernetes.io/version: "0.160.0"

--- a/charts/opentelemetry-collector/examples/using-shared-processes/rendered/configmap.yaml
+++ b/charts/opentelemetry-collector/examples/using-shared-processes/rendered/configmap.yaml
@@ -6,7 +6,7 @@ metadata:
   name: example-opentelemetry-collector
   namespace: default
   labels:
-    helm.sh/chart: opentelemetry-collector-0.173.0
+    helm.sh/chart: opentelemetry-collector-0.173.1
     app.kubernetes.io/name: opentelemetry-collector
     app.kubernetes.io/instance: example
     app.kubernetes.io/version: "0.160.0"

--- a/charts/opentelemetry-collector/examples/using-shared-processes/rendered/deployment.yaml
+++ b/charts/opentelemetry-collector/examples/using-shared-processes/rendered/deployment.yaml
@@ -6,7 +6,7 @@ metadata:
   name: example-opentelemetry-collector
   namespace: default
   labels:
-    helm.sh/chart: opentelemetry-collector-0.173.0
+    helm.sh/chart: opentelemetry-collector-0.173.1
     app.kubernetes.io/name: opentelemetry-collector
     app.kubernetes.io/instance: example
     app.kubernetes.io/version: "0.160.0"
@@ -26,7 +26,7 @@ spec:
   template:
     metadata:
       annotations:
-        checksum/config: 7c0bf33c0be34f870c3af2532a360fc9844bd75080b6f0e08f52e971ed6b50a3
+        checksum/config: e4ff59dfcded1b562c6b8ef93fad7a7c6954b8d279b8599f87252ae1caa773e2
         
       labels:
         app.kubernetes.io/name: opentelemetry-collector

--- a/charts/opentelemetry-collector/examples/using-shared-processes/rendered/service.yaml
+++ b/charts/opentelemetry-collector/examples/using-shared-processes/rendered/service.yaml
@@ -6,7 +6,7 @@ metadata:
   name: example-opentelemetry-collector
   namespace: default
   labels:
-    helm.sh/chart: opentelemetry-collector-0.173.0
+    helm.sh/chart: opentelemetry-collector-0.173.1
     app.kubernetes.io/name: opentelemetry-collector
     app.kubernetes.io/instance: example
     app.kubernetes.io/version: "0.160.0"

--- a/charts/opentelemetry-collector/examples/using-shared-processes/rendered/serviceaccount.yaml
+++ b/charts/opentelemetry-collector/examples/using-shared-processes/rendered/serviceaccount.yaml
@@ -6,7 +6,7 @@ metadata:
   name: example-opentelemetry-collector
   namespace: default
   labels:
-    helm.sh/chart: opentelemetry-collector-0.173.0
+    helm.sh/chart: opentelemetry-collector-0.173.1
     app.kubernetes.io/name: opentelemetry-collector
     app.kubernetes.io/instance: example
     app.kubernetes.io/version: "0.160.0"

--- a/charts/opentelemetry-collector/templates/_helpers.tpl
+++ b/charts/opentelemetry-collector/templates/_helpers.tpl
@@ -240,16 +240,23 @@ Create ConfigMap checksum annotation if configMap.existingPath is defined, other
 */}}
 {{- define "opentelemetry-collector.configTemplateChecksumAnnotation" -}}
   {{- if .Values.configMap.existingPath -}}
-  checksum/config: {{ include (print $.Template.BasePath "/" .Values.configMap.existingPath) . | sha256sum }}
+  checksum/config: {{ include "opentelemetry-collector.configChecksum" (dict "context" . "path" (print "/" .Values.configMap.existingPath)) }}
   {{- else -}}
     {{- if eq .Values.mode "daemonset" -}}
-    checksum/config: {{ include (print $.Template.BasePath "/configmap-agent.yaml") . | sha256sum }}
+    checksum/config: {{ include "opentelemetry-collector.configChecksum" (dict "context" . "path" "/configmap-agent.yaml") }}
     {{- else if eq .Values.mode "deployment" -}}
-    checksum/config: {{ include (print $.Template.BasePath "/configmap.yaml") . | sha256sum }}
+    checksum/config: {{ include "opentelemetry-collector.configChecksum" (dict "context" . "path" "/configmap.yaml") }}
     {{- else if eq .Values.mode "statefulset" -}}
-    checksum/config: {{ include (print $.Template.BasePath "/configmap-statefulset.yaml") . | sha256sum }}
+    checksum/config: {{ include "opentelemetry-collector.configChecksum" (dict "context" . "path" "/configmap-statefulset.yaml") }}
     {{- end -}}
   {{- end }}
+{{- end }}
+
+{{/*
+Hash only the data of a rendered ConfigMap, so that the chart labels on the manifest do not change the checksum
+*/}}
+{{- define "opentelemetry-collector.configChecksum" -}}
+{{- pick (include (print .context.Template.BasePath .path) .context | fromYaml) "data" "stringData" | toYaml | sha256sum -}}
 {{- end }}
 
 {{- define "opentelemetry-collector.deprecatedComponentRenames" -}}


### PR DESCRIPTION
#### Description

`checksum/config` hashes the entire rendered ConfigMap, and the manifest's `metadata.labels` include `helm.sh/chart`. That value changes on every chart version bump, so the annotation changed on every upgrade and rolled the collector pods even when the configuration was identical — in daemonset mode, that's every node in the cluster.

This adds an `opentelemetry-collector.configChecksum` helper that hashes only the `data`/`stringData` of the rendered ConfigMap, and uses it in `opentelemetry-collector.configTemplateChecksumAnnotation` for all four branches (daemonset, deployment, statefulset, and `configMap.existingPath`). A pure version bump no longer changes the checksum; any real config or preset change still does. Upgrading to 0.173.1 causes one final restart as the annotation value changes.

The argo-cd chart fixed the same issue in argoproj/argo-helm#4044, and the loki chart uses the same data-only hashing in `loki.configMapOrSecretContentHash`.

#### Link to tracking issue
Fixes

#### Authorship

- [x] I, a human, wrote this pull request description myself.